### PR TITLE
Add csvzen-core: zero-alloc streaming CSV writer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: tests
         run: sbt clean +test
 
-  formatting:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - run: env
@@ -40,5 +40,5 @@ jobs:
           distribution: temurin
           java-version: 17
           check-latest: true
-      - name: Formatting
-        run: sbt scalafmtSbtCheck scalafmtCheck test:scalafmtCheck
+      - name: scalafix + scalafmt check
+        run: sbt check

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,11 @@
+# This is a comment
+-Dfile.encoding=UTF8
+-Xms128M
+-Xmx4G
+-Xss16M
+-XX:+UseG1GC
+--add-opens=java.base/java.util=ALL-UNNAMED
+--add-opens=java.base/java.lang=ALL-UNNAMED
+--add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
+--enable-native-access=ALL-UNNAMED # Removes some warnings when starting sbt on JDK25+

--- a/.jvmopts
+++ b/.jvmopts
@@ -4,8 +4,4 @@
 -Xmx4G
 -Xss16M
 -XX:+UseG1GC
---add-opens=java.base/java.util=ALL-UNNAMED
---add-opens=java.base/java.lang=ALL-UNNAMED
---add-exports=java.base/sun.nio.ch=ALL-UNNAMED
---add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
 --enable-native-access=ALL-UNNAMED # Removes some warnings when starting sbt on JDK25+

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -4,7 +4,6 @@ rules = [
   LeakingImplicitClassVal
   NoAutoTupling
   NoValInForComprehension
-  OrganizeImports
   RemoveUnused
   RedundantSyntax
 ]
@@ -14,10 +13,3 @@ DisableSyntax.noReturns = true
 DisableSyntax.noXml = true
 DisableSyntax.noFinalize = true
 DisableSyntax.noValPatterns = true
-
-// Preset rules compatible with Intellij IDEA
-// See: https://scalacenter.github.io/scalafix/docs/rules/OrganizeImports.html#intellij_2020_3
-OrganizeImports {
-  preset = INTELLIJ_2020_3
-  targetDialect = Scala3
-}

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,23 @@
+rules = [
+  DisableSyntax
+  // ExplicitResultTypes // Waiting for: https://github.com/scalacenter/scalafix/issues/1583
+  LeakingImplicitClassVal
+  NoAutoTupling
+  NoValInForComprehension
+  OrganizeImports
+  RemoveUnused
+  RedundantSyntax
+]
+
+DisableSyntax.regex = []
+DisableSyntax.noReturns = true
+DisableSyntax.noXml = true
+DisableSyntax.noFinalize = true
+DisableSyntax.noValPatterns = true
+
+// Preset rules compatible with Intellij IDEA
+// See: https://scalacenter.github.io/scalafix/docs/rules/OrganizeImports.html#intellij_2020_3
+OrganizeImports {
+  preset = INTELLIJ_2020_3
+  targetDialect = Scala3
+}

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,31 @@
+version = "3.11.0"
+runner.dialect = scala3 # https://scalameta.org/scalafmt/docs/configuration.html#scala-3
+runner.dialectOverride.allowSignificantIndentation = false // See https://x.com/ghostdogpr/status/1706589471469425074
+maxColumn = 140
+align.preset = most
+continuationIndent.defnSite = 2
+assumeStandardLibraryStripMargin = true
+docstrings.style = Asterisk
+lineEndings = preserve
+includeCurlyBraceInSelectChains = true
+danglingParentheses.preset = true
+optIn.annotationNewlines = true
+newlines.alwaysBeforeMultilineDef = false
+newlines.implicitParamListModifierPrefer = before
+trailingCommas = keep
+docstrings.wrap = no
+
+rewrite.rules = [RedundantBraces, SortModifiers]
+
+rewrite.sortModifiers.order = [
+  "implicit", "override", "private", "protected", "final", "sealed", "abstract", "lazy"
+]
+rewrite.redundantBraces.generalExpressions = false
+rewrite.redundantBraces.stringInterpolation = true
+rewriteTokens = {
+  "⇒": "=>"
+  "→": "->"
+  "←": "<-"
+}
+
+project.excludePaths = []

--- a/README.md
+++ b/README.md
@@ -1,2 +1,198 @@
 # csvzen
-CSV made fast and simple
+
+CSV made fast and simple.
+
+A zero-allocation streaming CSV writer for **Scala 3**, built around a typed
+field emitter and compile-time-derived row encoders. RFC 4180 compliant by
+default, with configurable delimiter, quote character and line terminator.
+
+## Modules
+
+| Module        | Description                                               |
+|---------------|-----------------------------------------------------------|
+| `csvzen-core` | Streaming `CsvWriter`, `CsvConfig`, derived row encoders. |
+
+## Install
+
+`csvzen` targets Scala 3.3+ (LTS).
+
+```sbt
+libraryDependencies += "com.guizmaii" %% "csvzen-core" % "<latest-version>"
+```
+
+## Quick start
+
+### Write a case class to a file
+
+`derives CsvRowEncoder` gives you an encoder whose header names are the field
+labels in declaration order. `writeHeader[A]()` writes those labels; `writeAll`
+streams the rows.
+
+```scala
+import com.guizmaii.csvzen.core.*
+import java.nio.file.Paths
+
+final case class Person(name: String, age: Int, city: Option[String]) derives CsvRowEncoder
+
+val people = List(
+  Person("Ada",   36, Some("London")),
+  Person("Linus", 55, None),
+  Person("Grace", 85, Some("New York, NY")),
+)
+
+val path = Paths.get("people.csv")
+val writer = CsvWriter.open(path, CsvConfig.default)
+try {
+  writer.writeHeader[Person]()
+  writer.writeAll(people)
+} finally writer.close()
+```
+
+Output (`\r\n` terminators by default):
+
+```
+name,age,city
+Ada,36,London
+Linus,55,
+Grace,85,"New York, NY"
+```
+
+### Custom dialect
+
+`CsvConfig` controls delimiter, quote character and line terminator. Validation
+runs in the constructor — invalid combinations throw `IllegalArgumentException`.
+
+```scala
+val tsv = CsvConfig(delimiter = '\t', lineTerminator = "\n")
+val writer = CsvWriter.open(Paths.get("data.tsv"), tsv)
+```
+
+Allowed line terminators: `"\n"`, `"\r"`, `"\r\n"`.
+
+### Manual emission (escape hatch)
+
+When you don't want a derived encoder, take the `FieldEmitter` directly. Each
+`emit*` call writes one self-contained field; the writer handles delimiters and
+the row terminator.
+
+```scala
+writer.writeRow { e =>
+  e.emitString("hello")
+  e.emitInt(42)
+  e.emitDouble(3.14)
+  e.emitEmpty()           // empty cell
+}
+// hello,42,3.14,
+```
+
+### Charset and open options
+
+`CsvWriter.open` defaults to UTF-8 and the standard create/truncate behaviour.
+Pass a different `Charset` or `OpenOption`s when you need to:
+
+```scala
+import java.nio.charset.StandardCharsets
+import java.nio.file.StandardOpenOption
+
+val w = CsvWriter.open(
+  path,
+  CsvConfig.default,
+  StandardCharsets.ISO_8859_1,
+  StandardOpenOption.CREATE,
+  StandardOpenOption.APPEND,
+)
+```
+
+## Supported field types
+
+Out of the box, `CsvFieldEncoder` is provided for:
+
+- Primitives: `String`, `Int`, `Long`, `Short`, `Byte`, `Boolean`, `Char`,
+  `Float`, `Double`
+- Numeric: `BigInt`, `BigDecimal`
+- `UUID`, `Currency`
+- `java.time.*`: `Instant`, `LocalDate`, `LocalDateTime`, `LocalTime`,
+  `OffsetDateTime`, `OffsetTime`, `ZonedDateTime`, `Duration`, `Period`,
+  `Year`, `YearMonth`, `MonthDay`, `Month`, `DayOfWeek`, `ZoneId`, `ZoneOffset`
+- `Option[A]` for any supported `A` — `None` becomes an empty cell.
+
+### Custom encoders
+
+A `CsvFieldEncoder[A]` is a single method `(A, FieldEmitter) => Unit`. The
+emitter takes care of escaping; you choose the textual form.
+
+```scala
+import com.guizmaii.csvzen.core.*
+
+enum Color { case Red, Green, Blue }
+object Color {
+  given CsvFieldEncoder[Color] = (c, out) => out.emitString(c.toString.toLowerCase)
+}
+
+final case class Pixel(x: Int, y: Int, color: Color) derives CsvRowEncoder
+```
+
+### Writing only some fields of a case class
+
+`derives CsvRowEncoder` always emits every field. To project a subset (or
+reorder columns, or rename headers), build the encoder explicitly with
+`CsvRowEncoder.custom`:
+
+```scala
+import com.guizmaii.csvzen.core.*
+
+final case class User(
+  id: Long,
+  email: String,
+  passwordHash: String,   // sensitive — must not appear in the CSV
+  name: String,
+  createdAt: java.time.Instant,
+)
+object User {
+  given CsvRowEncoder[User] =
+    CsvRowEncoder.custom(IndexedSeq("id", "name", "email")) { (u, out) =>
+      out.emitLong(u.id)
+      out.emitString(u.name)
+      out.emitString(u.email)
+    }
+}
+
+// writeHeader[User]() and writeAll(users) now use this encoder and
+// emit only id, name, email — passwordHash and createdAt stay out.
+```
+
+## Escaping
+
+`csvzen` follows RFC 4180:
+
+- Fields containing the delimiter, the quote character, `\r` or `\n` are
+  enclosed in quotes.
+- Embedded quote characters are doubled.
+- Plain fields are written verbatim — no allocation, no copying.
+
+```
+he said "hi"   →   "he said ""hi"""
+a,b            →   "a,b"
+line1\nline2   →   "line1\nline2"
+```
+
+## Concurrency and error handling
+
+- A `CsvWriter` (and its `FieldEmitter`) holds mutable per-row state and
+  **must not** be shared across threads.
+- After an `IOException` from the underlying `Writer`, the writer is unusable.
+  csvzen does not attempt to recover from a partial row write — close the
+  writer and discard the file.
+- `flush()` flushes the underlying `Writer`; `close()` flushes and then
+  closes it.
+
+## Build
+
+```bash
+sbt --client tc        # Test/compile
+sbt --client test      # Run the test suite (ZIO Test)
+```
+
+## License
+
+[Apache 2.0](LICENSE)

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import BuildHelper.{noDoc, stdSettings}
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 ThisBuild / organization := "com.guizmaii"
-ThisBuild / name         := "scala-nimbus-jose-jwt"
+ThisBuild / name         := "csvzen"
 
 ThisBuild / scalafmtOnCompile := true
 ThisBuild / scalafmtCheck     := true
@@ -19,6 +19,7 @@ addCommandAlias("rctc", "reload; ctc")
 
 // ### Dependencies ###
 
+lazy val zioVersion = "2.1.25"
 
 // ### Modules ###
 
@@ -34,9 +35,13 @@ lazy val core =
     .in(file("core"))
     .settings(stdSettings *)
     .settings(
-      name := "csvzen-core"
+      name := "csvzen-core",
+      libraryDependencies ++= Seq(
+        "dev.zio" %% "zio-test"     % zioVersion % Test,
+        "dev.zio" %% "zio-test-sbt" % zioVersion % Test,
+      ),
+      testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     )
-
 
 inThisBuild(
   List(

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,6 @@ import BuildHelper.{noDoc, stdSettings}
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-ThisBuild / organization := "com.guizmaii"
-ThisBuild / name         := "csvzen"
-
 ThisBuild / scalaVersion      := "3.3.7"
 ThisBuild / scalafmtCheck     := true
 ThisBuild / scalafmtSbtCheck  := true

--- a/build.sbt
+++ b/build.sbt
@@ -5,11 +5,12 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 ThisBuild / organization := "com.guizmaii"
 ThisBuild / name         := "csvzen"
 
-ThisBuild / scalafmtOnCompile := true
+ThisBuild / scalaVersion      := "3.3.7"
 ThisBuild / scalafmtCheck     := true
 ThisBuild / scalafmtSbtCheck  := true
-
-ThisBuild / scalaVersion := "3.3.7"
+ThisBuild / scalafmtOnCompile := !insideCI.value
+ThisBuild / semanticdbEnabled := true
+ThisBuild / semanticdbVersion := scalafixSemanticdb.revision // use Scalafix compatible version
 
 // ### Aliases ###
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ ThisBuild / scalaVersion      := "3.3.7"
 ThisBuild / scalafmtCheck     := true
 ThisBuild / scalafmtSbtCheck  := true
 ThisBuild / scalafmtOnCompile := !insideCI.value
+ThisBuild / scalafixOnCompile := !insideCI.value
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbVersion := scalafixSemanticdb.revision // use Scalafix compatible version
 
@@ -14,6 +15,8 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision // use Scalafix com
 addCommandAlias("tc", "Test/compile")
 addCommandAlias("ctc", "clean; tc")
 addCommandAlias("rctc", "reload; ctc")
+addCommandAlias("fix", "scalafixAll; scalafmtAll; scalafmtSbt")
+addCommandAlias("check", "scalafixAll --check; scalafmtCheckAll; scalafmtSbtCheck")
 
 // ### Dependencies ###
 

--- a/core/src/main/scala/com/guizmaii/csvzen/core/CsvConfig.scala
+++ b/core/src/main/scala/com/guizmaii/csvzen/core/CsvConfig.scala
@@ -1,0 +1,19 @@
+package com.guizmaii.csvzen.core
+
+final case class CsvConfig(
+  delimiter: Char = ',',
+  quoteChar: Char = '"',
+  lineTerminator: String = "\r\n",
+) {
+  require(delimiter != quoteChar, "delimiter must differ from quoteChar")
+  require(delimiter != '\r' && delimiter != '\n', "delimiter must not be CR or LF")
+  require(quoteChar != '\r' && quoteChar != '\n', "quoteChar must not be CR or LF")
+  require(
+    lineTerminator == "\n" || lineTerminator == "\r" || lineTerminator == "\r\n",
+    "lineTerminator must be one of \"\\n\", \"\\r\", or \"\\r\\n\"",
+  )
+}
+
+object CsvConfig {
+  val default: CsvConfig = CsvConfig()
+}

--- a/core/src/main/scala/com/guizmaii/csvzen/core/CsvFieldEncoder.scala
+++ b/core/src/main/scala/com/guizmaii/csvzen/core/CsvFieldEncoder.scala
@@ -1,0 +1,67 @@
+package com.guizmaii.csvzen.core
+
+import java.time.{
+  DayOfWeek,
+  Duration,
+  Instant,
+  LocalDate,
+  LocalDateTime,
+  LocalTime,
+  Month,
+  MonthDay,
+  OffsetDateTime,
+  OffsetTime,
+  Period,
+  Year,
+  YearMonth,
+  ZoneId,
+  ZoneOffset,
+  ZonedDateTime,
+}
+import java.util.{Currency, UUID}
+
+trait CsvFieldEncoder[-A] {
+  def encode(a: A, out: FieldEmitter): Unit
+}
+
+object CsvFieldEncoder {
+
+  given stringEncoder: CsvFieldEncoder[String]   = (a, out) => out.emitString(a)
+  given intEncoder: CsvFieldEncoder[Int]         = (a, out) => out.emitInt(a)
+  given longEncoder: CsvFieldEncoder[Long]       = (a, out) => out.emitLong(a)
+  given shortEncoder: CsvFieldEncoder[Short]     = (a, out) => out.emitShort(a)
+  given byteEncoder: CsvFieldEncoder[Byte]       = (a, out) => out.emitByte(a)
+  given booleanEncoder: CsvFieldEncoder[Boolean] = (a, out) => out.emitBoolean(a)
+  given charEncoder: CsvFieldEncoder[Char]       = (a, out) => out.emitChar(a)
+
+  given floatEncoder: CsvFieldEncoder[Float]           = (a, out) => out.emitFloat(a)
+  given doubleEncoder: CsvFieldEncoder[Double]         = (a, out) => out.emitDouble(a)
+  given bigIntEncoder: CsvFieldEncoder[BigInt]         = (a, out) => out.emitString(a.toString)
+  given bigDecimalEncoder: CsvFieldEncoder[BigDecimal] = (a, out) => out.emitString(a.toString)
+  given uuidEncoder: CsvFieldEncoder[UUID]             = (a, out) => out.emitString(a.toString)
+  given currencyEncoder: CsvFieldEncoder[Currency]     = (a, out) => out.emitString(a.getCurrencyCode)
+
+  given dayOfWeekEncoder: CsvFieldEncoder[DayOfWeek]           = (a, out) => out.emitString(a.toString)
+  given durationEncoder: CsvFieldEncoder[Duration]             = (a, out) => out.emitString(a.toString)
+  given instantEncoder: CsvFieldEncoder[Instant]               = (a, out) => out.emitString(a.toString)
+  given localDateEncoder: CsvFieldEncoder[LocalDate]           = (a, out) => out.emitString(a.toString)
+  given localDateTimeEncoder: CsvFieldEncoder[LocalDateTime]   = (a, out) => out.emitString(a.toString)
+  given localTimeEncoder: CsvFieldEncoder[LocalTime]           = (a, out) => out.emitString(a.toString)
+  given monthEncoder: CsvFieldEncoder[Month]                   = (a, out) => out.emitString(a.toString)
+  given monthDayEncoder: CsvFieldEncoder[MonthDay]             = (a, out) => out.emitString(a.toString)
+  given offsetDateTimeEncoder: CsvFieldEncoder[OffsetDateTime] = (a, out) => out.emitString(a.toString)
+  given offsetTimeEncoder: CsvFieldEncoder[OffsetTime]         = (a, out) => out.emitString(a.toString)
+  given periodEncoder: CsvFieldEncoder[Period]                 = (a, out) => out.emitString(a.toString)
+  given yearEncoder: CsvFieldEncoder[Year]                     = (a, out) => out.emitString(a.toString)
+  given yearMonthEncoder: CsvFieldEncoder[YearMonth]           = (a, out) => out.emitString(a.toString)
+  given zoneIdEncoder: CsvFieldEncoder[ZoneId]                 = (a, out) => out.emitString(a.toString)
+  given zoneOffsetEncoder: CsvFieldEncoder[ZoneOffset]         = (a, out) => out.emitString(a.toString)
+  given zonedDateTimeEncoder: CsvFieldEncoder[ZonedDateTime]   = (a, out) => out.emitString(a.toString)
+
+  given optionEncoder[A](using inner: CsvFieldEncoder[A]): CsvFieldEncoder[Option[A]] = { (a, out) =>
+    a match {
+      case Some(v) => inner.encode(v, out)
+      case None    => out.emitEmpty()
+    }
+  }
+}

--- a/core/src/main/scala/com/guizmaii/csvzen/core/CsvRowEncoder.scala
+++ b/core/src/main/scala/com/guizmaii/csvzen/core/CsvRowEncoder.scala
@@ -1,0 +1,43 @@
+package com.guizmaii.csvzen.core
+
+import scala.compiletime.{constValueTuple, summonAll}
+import scala.deriving.Mirror
+
+trait CsvRowEncoder[-A] {
+  def headerNames: IndexedSeq[String]
+  def encode(a: A, out: FieldEmitter): Unit
+}
+
+object CsvRowEncoder {
+
+  inline def derived[A <: Product](using m: Mirror.ProductOf[A]): CsvRowEncoder[A] = {
+    val labels   = labelsOf[m.MirroredElemLabels]
+    val encoders = encodersOf[m.MirroredElemTypes]
+    new internal.DerivedCsvRowEncoder[A](labels, encoders)
+  }
+
+  inline private def labelsOf[L <: Tuple]: Array[String] = {
+    val arr = constValueTuple[L].toArray
+    val out = new Array[String](arr.length)
+    var i   = 0
+    while (i < arr.length) {
+      out(i) = arr(i).asInstanceOf[String]
+      i += 1
+    }
+    out
+  }
+
+  // Unsafe cast: contravariance makes `CsvFieldEncoder[X] <: CsvFieldEncoder[Any]` a
+  // narrowing, not a widening. Safe here because DerivedCsvRowEncoder.encode only ever
+  // feeds slot i the matching `productElement(i)` value for that position.
+  inline private def encodersOf[E <: Tuple]: Array[CsvFieldEncoder[Any]] = {
+    val arr = summonAll[Tuple.Map[E, CsvFieldEncoder]].toArray
+    val out = new Array[CsvFieldEncoder[Any]](arr.length)
+    var i   = 0
+    while (i < arr.length) {
+      out(i) = arr(i).asInstanceOf[CsvFieldEncoder[Any]]
+      i += 1
+    }
+    out
+  }
+}

--- a/core/src/main/scala/com/guizmaii/csvzen/core/CsvRowEncoder.scala
+++ b/core/src/main/scala/com/guizmaii/csvzen/core/CsvRowEncoder.scala
@@ -1,5 +1,6 @@
 package com.guizmaii.csvzen.core
 
+import scala.annotation.nowarn
 import scala.compiletime.{constValueTuple, summonAll}
 import scala.deriving.Mirror
 
@@ -15,6 +16,15 @@ object CsvRowEncoder {
     val encoders = encodersOf[m.MirroredElemTypes]
     new internal.DerivedCsvRowEncoder[A](labels, encoders)
   }
+
+  @nowarn("id=E197")
+  inline def custom[A](
+    inline headers: IndexedSeq[String]
+  )(inline encodeFn: (A, FieldEmitter) => Unit): CsvRowEncoder[A] =
+    new CsvRowEncoder[A] {
+      override val headerNames: IndexedSeq[String]       = headers
+      override def encode(a: A, out: FieldEmitter): Unit = encodeFn(a, out)
+    }
 
   inline private def labelsOf[L <: Tuple]: Array[String] = {
     val arr = constValueTuple[L].toArray

--- a/core/src/main/scala/com/guizmaii/csvzen/core/CsvWriter.scala
+++ b/core/src/main/scala/com/guizmaii/csvzen/core/CsvWriter.scala
@@ -1,0 +1,75 @@
+package com.guizmaii.csvzen.core
+
+import java.io.Writer
+import java.nio.charset.{Charset, StandardCharsets}
+import java.nio.file.{Files, OpenOption, Path}
+
+/**
+ * Streaming CSV writer.
+ *
+ * Not thread-safe: a single instance must not be used concurrently from multiple threads.
+ * The underlying `FieldEmitter` holds mutable per-row state.
+ *
+ * Unusable after any `IOException` from the underlying `Writer`. csvzen does not attempt
+ * to recover from partial row writes; a caller that catches a mid-row failure must close
+ * the writer and discard the file rather than writing further rows.
+ */
+final class CsvWriter private[core] (out: Writer, config: CsvConfig) extends AutoCloseable {
+
+  private[core] val emitter: FieldEmitter = new FieldEmitter(out, config)
+
+  inline def writeRow[A](a: A)(using enc: CsvRowEncoder[A]): Unit = {
+    emitter.beginRow()
+    enc.encode(a, emitter)
+    emitter.endRow()
+  }
+
+  inline def writeRow(inline body: FieldEmitter => Unit): Unit = {
+    emitter.beginRow()
+    body(emitter)
+    emitter.endRow()
+  }
+
+  inline def writeHeader[A]()(using enc: CsvRowEncoder[A]): Unit = writeHeader(enc.headerNames)
+
+  def writeHeader(names: IndexedSeq[String]): Unit = {
+    emitter.beginRow()
+    val n = names.length
+    var i = 0
+    while (i < n) {
+      emitter.emitString(names(i))
+      i += 1
+    }
+    emitter.endRow()
+  }
+
+  inline def writeAll[A](rows: Iterable[A])(using enc: CsvRowEncoder[A]): Unit = {
+    val it = rows.iterator
+    while (it.hasNext) writeRow(it.next())
+  }
+
+  /** Flushes the underlying `Writer`, pushing buffered bytes to disk. */
+  def flush(): Unit = out.flush()
+
+  override def close(): Unit = out.close()
+}
+
+object CsvWriter {
+
+  /**
+   * Opens a buffered CSV writer on `path`. Defaults to UTF-8 and the standard
+   * `newBufferedWriter` open options (`CREATE`, `TRUNCATE_EXISTING`, `WRITE`). Pass a
+   * different `charset` for e.g. ISO-8859-1, and additional `options` such as
+   * `StandardOpenOption.APPEND` to control create/truncate/append behaviour.
+   */
+  def open(
+    path: Path,
+    config: CsvConfig,
+    charset: Charset = StandardCharsets.UTF_8,
+    options: OpenOption*,
+  ): CsvWriter =
+    new CsvWriter(Files.newBufferedWriter(path, charset, options*), config)
+
+  private[core] def unsafeFromWriter(out: Writer, config: CsvConfig): CsvWriter =
+    new CsvWriter(out, config)
+}

--- a/core/src/main/scala/com/guizmaii/csvzen/core/CsvWriter.scala
+++ b/core/src/main/scala/com/guizmaii/csvzen/core/CsvWriter.scala
@@ -1,6 +1,6 @@
 package com.guizmaii.csvzen.core
 
-import java.io.Writer
+import java.io.{Flushable, Writer}
 import java.nio.charset.{Charset, StandardCharsets}
 import java.nio.file.{Files, OpenOption, Path}
 
@@ -14,7 +14,7 @@ import java.nio.file.{Files, OpenOption, Path}
  * to recover from partial row writes; a caller that catches a mid-row failure must close
  * the writer and discard the file rather than writing further rows.
  */
-final class CsvWriter private[core] (out: Writer, config: CsvConfig) extends AutoCloseable {
+final class CsvWriter private[core] (out: Writer, config: CsvConfig) extends AutoCloseable with Flushable {
 
   private[core] val emitter: FieldEmitter = new FieldEmitter(out, config)
 
@@ -49,8 +49,9 @@ final class CsvWriter private[core] (out: Writer, config: CsvConfig) extends Aut
   }
 
   /** Flushes the underlying `Writer`, pushing buffered bytes to disk. */
-  def flush(): Unit = out.flush()
+  override def flush(): Unit = out.flush()
 
+  /** Flushes and closes the underlying `Writer` (`Writer.close` flushes before closing). */
   override def close(): Unit = out.close()
 }
 

--- a/core/src/main/scala/com/guizmaii/csvzen/core/FieldEmitter.scala
+++ b/core/src/main/scala/com/guizmaii/csvzen/core/FieldEmitter.scala
@@ -73,8 +73,12 @@ final class FieldEmitter private[core] (out: Writer, config: CsvConfig) {
     out.write(java.lang.Double.toString(d))
   }
 
-  // Process digits in the non-positive domain so Int.MinValue / Long.MinValue need no
-  // special case (their absolute value has no positive Int/Long representation).
+  // Process digits with `n <= 0` throughout the loop. Positive inputs are negated
+  // once on entry so a single `('0' - n % 10)` extraction handles both signs. This
+  // avoids the Int.MinValue / Long.MinValue special case: their absolute value has
+  // no positive Int/Long representation, so we never compute it — we keep the
+  // original negative number and extract digits from it directly. Same trick the
+  // JDK's own digit conversion uses (see java.lang.Integer.getChars).
   private def writeInt(i: Int): Unit = {
     var n    = i
     if (n < 0) out.write('-'.toInt)

--- a/core/src/main/scala/com/guizmaii/csvzen/core/FieldEmitter.scala
+++ b/core/src/main/scala/com/guizmaii/csvzen/core/FieldEmitter.scala
@@ -73,43 +73,37 @@ final class FieldEmitter private[core] (out: Writer, config: CsvConfig) {
     out.write(java.lang.Double.toString(d))
   }
 
-  private def writeInt(i: Int): Unit =
-    if (i == Integer.MIN_VALUE) out.write("-2147483648")
-    else {
-      var n    = i
-      if (n < 0) {
-        out.write('-'.toInt)
-        n = -n
-      }
-      var pos  = scratch.length
-      var cont = true
-      while (cont) {
-        pos -= 1
-        scratch(pos) = ('0' + (n % 10)).toChar
-        n /= 10
-        cont = n != 0
-      }
-      out.write(scratch, pos, scratch.length - pos)
+  // Process digits in the non-positive domain so Int.MinValue / Long.MinValue need no
+  // special case (their absolute value has no positive Int/Long representation).
+  private def writeInt(i: Int): Unit = {
+    var n    = i
+    if (n < 0) out.write('-'.toInt)
+    else n = -n
+    var pos  = scratch.length
+    var cont = true
+    while (cont) {
+      pos -= 1
+      scratch(pos) = ('0' - (n % 10)).toChar
+      n /= 10
+      cont = n != 0
     }
+    out.write(scratch, pos, scratch.length - pos)
+  }
 
-  private def writeLong(l: Long): Unit =
-    if (l == java.lang.Long.MIN_VALUE) out.write("-9223372036854775808")
-    else {
-      var n    = l
-      if (n < 0L) {
-        out.write('-'.toInt)
-        n = -n
-      }
-      var pos  = scratch.length
-      var cont = true
-      while (cont) {
-        pos -= 1
-        scratch(pos) = ('0' + (n % 10L)).toChar
-        n /= 10L
-        cont = n != 0L
-      }
-      out.write(scratch, pos, scratch.length - pos)
+  private def writeLong(l: Long): Unit = {
+    var n    = l
+    if (n < 0L) out.write('-'.toInt)
+    else n = -n
+    var pos  = scratch.length
+    var cont = true
+    while (cont) {
+      pos -= 1
+      scratch(pos) = ('0' - (n % 10L)).toChar
+      n /= 10L
+      cont = n != 0L
     }
+    out.write(scratch, pos, scratch.length - pos)
+  }
 
   private def writeEscaped(s: String): Unit = {
     val len          = s.length

--- a/core/src/main/scala/com/guizmaii/csvzen/core/FieldEmitter.scala
+++ b/core/src/main/scala/com/guizmaii/csvzen/core/FieldEmitter.scala
@@ -16,7 +16,10 @@ final class FieldEmitter private[core] (out: Writer, config: CsvConfig) {
   private val quoteChar: Char        = config.quoteChar
   private val lineTerminator: String = config.lineTerminator
   private var first: Boolean         = true
-  private val scratch: Array[Char]   = new Array[Char](20)
+  // Reusable digit buffer for writeInt / writeLong. 19 chars is the max any signed
+  // integer type produces here: Long.MinValue's absolute value is 9223372036854775808
+  // (19 digits) and the sign is written separately, so it never enters this array.
+  private val scratch: Array[Char]   = new Array[Char](19)
 
   private[core] def beginRow(): Unit = first = true
 

--- a/core/src/main/scala/com/guizmaii/csvzen/core/FieldEmitter.scala
+++ b/core/src/main/scala/com/guizmaii/csvzen/core/FieldEmitter.scala
@@ -1,0 +1,156 @@
+package com.guizmaii.csvzen.core
+
+import java.io.Writer
+
+/**
+ * Typed, mostly-zero-allocation CSV field emitter. Each `emit*` call writes a
+ * self-contained field, automatically prefixing the delimiter when it is not the first
+ * field of the current row.
+ *
+ * Not thread-safe: holds mutable per-row state (`first` flag and integer scratch buffer);
+ * one instance must not be used concurrently from multiple threads.
+ */
+final class FieldEmitter private[core] (out: Writer, config: CsvConfig) {
+
+  private val delimiter: Char        = config.delimiter
+  private val quoteChar: Char        = config.quoteChar
+  private val lineTerminator: String = config.lineTerminator
+  private var first: Boolean         = true
+  private val scratch: Array[Char]   = new Array[Char](20)
+
+  private[core] def beginRow(): Unit = first = true
+
+  private[core] def endRow(): Unit = out.write(lineTerminator)
+
+  private def fieldPrelude(): Unit =
+    if (!first) out.write(delimiter.toInt)
+    else first = false
+
+  def emitEmpty(): Unit = fieldPrelude()
+
+  def emitString(s: String): Unit = {
+    fieldPrelude()
+    writeEscaped(s)
+  }
+
+  def emitBoolean(b: Boolean): Unit = {
+    fieldPrelude()
+    out.write(if (b) "true" else "false")
+  }
+
+  def emitInt(i: Int): Unit = {
+    fieldPrelude()
+    writeInt(i)
+  }
+
+  def emitLong(l: Long): Unit = {
+    fieldPrelude()
+    writeLong(l)
+  }
+
+  def emitShort(s: Short): Unit = {
+    fieldPrelude()
+    writeInt(s.toInt)
+  }
+
+  def emitByte(b: Byte): Unit = {
+    fieldPrelude()
+    writeInt(b.toInt)
+  }
+
+  def emitChar(c: Char): Unit = {
+    fieldPrelude()
+    writeEscapedChar(c)
+  }
+
+  def emitFloat(f: Float): Unit = {
+    fieldPrelude()
+    out.write(java.lang.Float.toString(f))
+  }
+
+  def emitDouble(d: Double): Unit = {
+    fieldPrelude()
+    out.write(java.lang.Double.toString(d))
+  }
+
+  private def writeInt(i: Int): Unit =
+    if (i == Integer.MIN_VALUE) out.write("-2147483648")
+    else {
+      var n    = i
+      if (n < 0) {
+        out.write('-'.toInt)
+        n = -n
+      }
+      var pos  = scratch.length
+      var cont = true
+      while (cont) {
+        pos -= 1
+        scratch(pos) = ('0' + (n % 10)).toChar
+        n /= 10
+        cont = n != 0
+      }
+      out.write(scratch, pos, scratch.length - pos)
+    }
+
+  private def writeLong(l: Long): Unit =
+    if (l == java.lang.Long.MIN_VALUE) out.write("-9223372036854775808")
+    else {
+      var n    = l
+      if (n < 0L) {
+        out.write('-'.toInt)
+        n = -n
+      }
+      var pos  = scratch.length
+      var cont = true
+      while (cont) {
+        pos -= 1
+        scratch(pos) = ('0' + (n % 10L)).toChar
+        n /= 10L
+        cont = n != 0L
+      }
+      out.write(scratch, pos, scratch.length - pos)
+    }
+
+  private def writeEscaped(s: String): Unit = {
+    val len          = s.length
+    var needsQuoting = false
+    var hasQuote     = false
+    var i            = 0
+    while (i < len) {
+      val c = s.charAt(i)
+      // Check quoteChar first: if a pathological config aliases it with the
+      // delimiter or a line terminator, we must still mark hasQuote so that the
+      // emission pass doubles the embedded quotes.
+      if (c == quoteChar) {
+        needsQuoting = true
+        hasQuote = true
+      } else if (c == delimiter || c == '\r' || c == '\n') needsQuoting = true
+      i += 1
+    }
+    if (!needsQuoting) out.write(s)
+    else {
+      out.write(quoteChar.toInt)
+      if (hasQuote) {
+        i = 0
+        while (i < len) {
+          val c = s.charAt(i)
+          if (c == quoteChar) out.write(quoteChar.toInt)
+          out.write(c.toInt)
+          i += 1
+        }
+      } else out.write(s)
+      out.write(quoteChar.toInt)
+    }
+  }
+
+  private def writeEscapedChar(c: Char): Unit = {
+    val needsQuoting = c == delimiter || c == quoteChar || c == '\r' || c == '\n'
+    if (!needsQuoting) out.write(c.toInt)
+    else {
+      out.write(quoteChar.toInt)
+      if (c == quoteChar) out.write(quoteChar.toInt)
+      out.write(c.toInt)
+      out.write(quoteChar.toInt)
+    }
+  }
+}

--- a/core/src/main/scala/com/guizmaii/csvzen/core/internal/DerivedCsvRowEncoder.scala
+++ b/core/src/main/scala/com/guizmaii/csvzen/core/internal/DerivedCsvRowEncoder.scala
@@ -10,9 +10,9 @@ final class DerivedCsvRowEncoder[A <: Product](
 
   private val n: Int = encoders.length
 
-  val headerNames: IndexedSeq[String] = ArraySeq.unsafeWrapArray(labels)
+  override val headerNames: IndexedSeq[String] = ArraySeq.unsafeWrapArray(labels)
 
-  def encode(a: A, out: FieldEmitter): Unit = {
+  override def encode(a: A, out: FieldEmitter): Unit = {
     var i = 0
     while (i < n) {
       encoders(i).encode(a.productElement(i), out)

--- a/core/src/main/scala/com/guizmaii/csvzen/core/internal/DerivedCsvRowEncoder.scala
+++ b/core/src/main/scala/com/guizmaii/csvzen/core/internal/DerivedCsvRowEncoder.scala
@@ -1,0 +1,21 @@
+package com.guizmaii.csvzen.core
+package internal
+
+import scala.collection.immutable.ArraySeq
+
+final class DerivedCsvRowEncoder[A <: Product](
+  labels: Array[String],
+  encoders: Array[CsvFieldEncoder[Any]],
+) extends CsvRowEncoder[A] {
+
+  val headerNames: IndexedSeq[String] = ArraySeq.unsafeWrapArray(labels)
+
+  def encode(a: A, out: FieldEmitter): Unit = {
+    val n = encoders.length
+    var i = 0
+    while (i < n) {
+      encoders(i).encode(a.productElement(i), out)
+      i += 1
+    }
+  }
+}

--- a/core/src/main/scala/com/guizmaii/csvzen/core/internal/DerivedCsvRowEncoder.scala
+++ b/core/src/main/scala/com/guizmaii/csvzen/core/internal/DerivedCsvRowEncoder.scala
@@ -8,10 +8,11 @@ final class DerivedCsvRowEncoder[A <: Product](
   encoders: Array[CsvFieldEncoder[Any]],
 ) extends CsvRowEncoder[A] {
 
+  private val n: Int = encoders.length
+
   val headerNames: IndexedSeq[String] = ArraySeq.unsafeWrapArray(labels)
 
   def encode(a: A, out: FieldEmitter): Unit = {
-    val n = encoders.length
     var i = 0
     while (i < n) {
       encoders(i).encode(a.productElement(i), out)

--- a/core/src/test/scala/com/guizmaii/csvzen/core/CsvFieldEncoderSpec.scala
+++ b/core/src/test/scala/com/guizmaii/csvzen/core/CsvFieldEncoderSpec.scala
@@ -1,0 +1,152 @@
+package com.guizmaii.csvzen.core
+
+import zio.Scope
+import zio.test.*
+
+import java.io.StringWriter
+import java.time.*
+import java.util.{Currency, UUID}
+
+object CsvFieldEncoderSpec extends ZIOSpecDefault {
+
+  private def encodeOne[A](a: A)(using enc: CsvFieldEncoder[A]): String = {
+    val sw = new StringWriter
+    val w  = CsvWriter.unsafeFromWriter(sw, CsvConfig.default)
+    try w.writeRow(e => enc.encode(a, e))
+    finally w.close()
+    sw.toString.stripSuffix("\r\n")
+  }
+
+  private val primitives =
+    suite("primitive encoders")(
+      test("String nominal and empty") {
+        assertTrue(
+          encodeOne("hello") == "hello",
+          encodeOne("") == "",
+          encodeOne("with,comma") == "\"with,comma\"",
+        )
+      },
+      test("Int boundaries") {
+        assertTrue(
+          encodeOne(0) == "0",
+          encodeOne(Int.MaxValue) == Int.MaxValue.toString,
+          encodeOne(Int.MinValue) == Int.MinValue.toString,
+        )
+      },
+      test("Long boundaries") {
+        assertTrue(
+          encodeOne(Long.MaxValue) == Long.MaxValue.toString,
+          encodeOne(Long.MinValue) == Long.MinValue.toString,
+        )
+      },
+      test("Short boundaries") {
+        assertTrue(
+          encodeOne(Short.MaxValue) == Short.MaxValue.toString,
+          encodeOne(Short.MinValue) == Short.MinValue.toString,
+        )
+      },
+      test("Byte boundaries") {
+        assertTrue(
+          encodeOne(Byte.MaxValue) == Byte.MaxValue.toString,
+          encodeOne(Byte.MinValue) == Byte.MinValue.toString,
+        )
+      },
+      test("Boolean") {
+        assertTrue(encodeOne(true) == "true", encodeOne(false) == "false")
+      },
+      test("Char plain and special") {
+        assertTrue(encodeOne('a') == "a", encodeOne(',') == "\",\"", encodeOne('"') == "\"\"\"\"")
+      },
+      test("Float") {
+        assertTrue(encodeOne(1.5f) == "1.5", encodeOne(0.0f) == "0.0")
+      },
+      test("Double") {
+        assertTrue(encodeOne(1.5) == "1.5", encodeOne(math.Pi) == math.Pi.toString)
+      },
+    )
+
+  private val carveOutValues =
+    suite("carve-out encoders (BigInt, BigDecimal, UUID, Currency)")(
+      test("BigInt") {
+        assertTrue(encodeOne(BigInt("123456789012345678901234567890")) == "123456789012345678901234567890")
+      },
+      test("BigDecimal with scale") {
+        val bd = BigDecimal("3.14159265358979323846")
+        assertTrue(encodeOne(bd) == bd.toString)
+      },
+      test("UUID random and deterministic") {
+        val u1 = UUID.randomUUID()
+        val u2 = UUID.nameUUIDFromBytes("csvzen".getBytes("UTF-8"))
+        assertTrue(encodeOne(u1) == u1.toString, encodeOne(u2) == u2.toString)
+      },
+      test("Currency codes") {
+        val ok = Seq("EUR", "USD", "JPY").forall { code =>
+          encodeOne(Currency.getInstance(code)) == code
+        }
+        assertTrue(ok)
+      },
+    )
+
+  private val javaTimeValues =
+    suite("java.time encoders")(
+      test("DayOfWeek covers every value") {
+        assertTrue(DayOfWeek.values.toSeq.forall(d => encodeOne(d) == d.toString))
+      },
+      test("Month covers every value") {
+        assertTrue(Month.values.toSeq.forall(m => encodeOne(m) == m.toString))
+      },
+      test("Duration canonical form") {
+        val d = Duration.ofSeconds(125, 500)
+        assertTrue(encodeOne(d) == d.toString)
+      },
+      test("Instant near epoch and nanosecond precision") {
+        val i = Instant.parse("2026-04-24T12:00:00.123456789Z")
+        assertTrue(encodeOne(i) == i.toString)
+      },
+      test("LocalDate, LocalDateTime, LocalTime") {
+        val d  = LocalDate.of(2026, 4, 24)
+        val dt = LocalDateTime.of(2026, 4, 24, 12, 0, 0, 123456789)
+        val t  = LocalTime.of(12, 0, 0, 123456789)
+        assertTrue(encodeOne(d) == d.toString, encodeOne(dt) == dt.toString, encodeOne(t) == t.toString)
+      },
+      test("MonthDay, Period, Year, YearMonth") {
+        val md = MonthDay.of(4, 24)
+        val p  = Period.of(1, 2, 3)
+        val y  = Year.of(2026)
+        val ym = YearMonth.of(2026, 4)
+        assertTrue(
+          encodeOne(md) == md.toString,
+          encodeOne(p) == p.toString,
+          encodeOne(y) == y.toString,
+          encodeOne(ym) == ym.toString,
+        )
+      },
+      test("OffsetDateTime, OffsetTime") {
+        val odt = OffsetDateTime.parse("2026-04-24T12:00:00+02:00")
+        val ot  = OffsetTime.parse("12:00:00+02:00")
+        assertTrue(encodeOne(odt) == odt.toString, encodeOne(ot) == ot.toString)
+      },
+      test("ZoneId, ZoneOffset, ZonedDateTime") {
+        val z   = ZoneId.of("Europe/Paris")
+        val zo  = ZoneOffset.ofHours(-5)
+        val zdt = ZonedDateTime.parse("2026-04-24T12:00:00+02:00[Europe/Paris]")
+        assertTrue(encodeOne(z) == z.toString, encodeOne(zo) == zo.toString, encodeOne(zdt) == zdt.toString)
+      },
+    )
+
+  private val optionSpec =
+    suite("Option encoder")(
+      test("None emits empty cell") {
+        assertTrue(encodeOne[Option[Int]](None) == "")
+      },
+      test("Some delegates to inner encoder") {
+        assertTrue(encodeOne[Option[Int]](Some(42)) == "42", encodeOne[Option[String]](Some("hi")) == "hi")
+      },
+      test("Some with String containing specials is quoted") {
+        assertTrue(encodeOne[Option[String]](Some("a,b")) == "\"a,b\"")
+      },
+    )
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("CsvFieldEncoder")(primitives, carveOutValues, javaTimeValues, optionSpec)
+}

--- a/core/src/test/scala/com/guizmaii/csvzen/core/CsvFileWriterSpec.scala
+++ b/core/src/test/scala/com/guizmaii/csvzen/core/CsvFileWriterSpec.scala
@@ -1,0 +1,363 @@
+package com.guizmaii.csvzen.core
+
+import zio.Scope
+import zio.test.*
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.time.{
+  DayOfWeek,
+  Duration,
+  Instant,
+  LocalDate,
+  LocalDateTime,
+  LocalTime,
+  Month,
+  MonthDay,
+  OffsetDateTime,
+  OffsetTime,
+  Period,
+  Year,
+  YearMonth,
+  ZoneId,
+  ZoneOffset,
+  ZonedDateTime,
+}
+import java.util.{Currency, UUID}
+
+object CsvFileWriterSpec extends ZIOSpecDefault {
+
+  private def withTmpFile[A](body: Path => A): A = {
+    val p = Files.createTempFile("csvzen-", ".csv")
+    try body(p)
+    finally { val _ = Files.deleteIfExists(p) }
+  }
+
+  private def writeAndRead(
+    config: CsvConfig = CsvConfig.default,
+  )(body: CsvWriter => Unit): (String, Array[Byte]) =
+    withTmpFile { p =>
+      val w     = CsvWriter.open(p, config)
+      try body(w)
+      finally w.close()
+      val str   = Files.readString(p, StandardCharsets.UTF_8)
+      val bytes = Files.readAllBytes(p)
+      (str, bytes)
+    }
+
+  private val utf8Spec =
+    suite("UTF-8 correctness")(
+      test("writes emoji, CJK, and accented chars as valid UTF-8") {
+        val (s, _) = writeAndRead() { w =>
+          w.writeRow(_.emitString("é日本語🎉→"))
+        }
+        assertTrue(s == "é日本語🎉→\r\n")
+      },
+      test("emoji round-trip: exact byte sequence matches UTF-8 encoding") {
+        val text           = "🎉"
+        val (_, bytes)     = writeAndRead() { w =>
+          w.writeRow(_.emitString(text))
+        }
+        val expectedPrefix = text.getBytes(StandardCharsets.UTF_8)
+        val got            = bytes.take(expectedPrefix.length)
+        val matches        = got.sameElements(expectedPrefix)
+        assertTrue(matches)
+      },
+      test("no BOM is written") {
+        val (_, bytes) = writeAndRead() { w =>
+          w.writeRow(_.emitString("a"))
+        }
+        assertTrue(bytes(0) == 'a'.toByte)
+      },
+    )
+
+  private val terminatorSpec =
+    suite("line terminators")(
+      test("default \\r\\n at end of each row") {
+        val (_, bytes) = writeAndRead() { w =>
+          w.writeRow(_.emitString("a"))
+        }
+        val last       = bytes.takeRight(2)
+        assertTrue(last(0) == 0x0d.toByte, last(1) == 0x0a.toByte)
+      },
+      test("LF-only terminator writes exactly 0x0A") {
+        val cfg        = CsvConfig(lineTerminator = "\n")
+        val (_, bytes) = writeAndRead(cfg) { w =>
+          w.writeRow(_.emitString("a"))
+        }
+        assertTrue(bytes.last == 0x0a.toByte, !bytes.contains(0x0d.toByte))
+      },
+      test("no stray terminator appended beyond what rows emitted") {
+        val (s, _) = writeAndRead() { w =>
+          w.writeRow(_.emitString("x"))
+          w.writeRow(_.emitString("y"))
+        }
+        assertTrue(s == "x\r\ny\r\n")
+      },
+    )
+
+  private val emptyAndHeaderSpec =
+    suite("empty and header-only files")(
+      test("empty file: open + close with no writes produces 0-byte file") {
+        val (_, bytes) = writeAndRead()(_ => ())
+        assertTrue(bytes.length == 0)
+      },
+      test("header-only file: exactly one terminated line") {
+        final case class H(a: Int, b: String) derives CsvRowEncoder
+        val (s, _) = writeAndRead()(w => w.writeHeader[H]())
+        assertTrue(s == "a,b\r\n")
+      },
+    )
+
+  private val largeFileSpec = {
+    final case class Big(id: Int, name: String, flag: Boolean, note: Option[String]) derives CsvRowEncoder
+    suite("large file")(
+      test("100k mixed-type rows round-trip correctly (line count + sentinels)") {
+        val n      = 100_000
+        val (s, _) = writeAndRead() { w =>
+          w.writeHeader[Big]()
+          var i = 0
+          while (i < n) {
+            val note = if (i % 7 == 0) Some("with,comma") else None
+            w.writeRow(Big(i, s"r$i", (i % 2) == 0, note))
+            i += 1
+          }
+        }
+        val parsed = TestCsvReader.parse(s)
+        assertTrue(
+          parsed.length == n + 1,
+          parsed.head == Vector("id", "name", "flag", "note"),
+          parsed(1) == Vector("0", "r0", "true", "with,comma"),
+          parsed.last == Vector((n - 1).toString, s"r${n - 1}", ((n - 1) % 2 == 0).toString, ""),
+        )
+      }
+    )
+  }
+
+  private val quotingRoundTripSpec =
+    suite("quoting round-trip via TestCsvReader")(
+      test("parse-back matrix of escape cases") {
+        val inputs = Seq(
+          "plain",
+          "",
+          "a,b",
+          "a\"b",
+          "a\nb",
+          "a\rb",
+          "a\r\nb",
+          "\"starts",
+          "ends\"",
+          "double \"\" inside",
+          "日本語",
+          "mixed,\"and\"\nstuff",
+        )
+        val (s, _) = writeAndRead() { w =>
+          inputs.foreach(in => w.writeRow(_.emitString(in)))
+        }
+        val parsed = TestCsvReader.parse(s)
+        assertTrue(parsed == inputs.map(Vector(_)).toVector)
+      },
+      test("TSV with hash quote round-trips") {
+        val cfg    = CsvConfig(delimiter = '\t', quoteChar = '#')
+        val inputs = Seq("a\tb", "c#d", "normal", "")
+        val (s, _) = writeAndRead(cfg) { w =>
+          inputs.foreach(in => w.writeRow(_.emitString(in)))
+        }
+        val parsed = TestCsvReader.parse(s, cfg)
+        assertTrue(parsed == inputs.map(Vector(_)).toVector)
+      },
+    )
+
+  private val overwriteAndMissingDirSpec =
+    suite("file-level semantics")(
+      test("opening on an existing file truncates") {
+        withTmpFile { p =>
+          Files.writeString(p, "PREEXISTING CONTENT THAT SHOULD BE GONE\r\n", StandardCharsets.UTF_8)
+          val w    = CsvWriter.open(p, CsvConfig.default)
+          try w.writeRow(_.emitString("new"))
+          finally w.close()
+          val read = Files.readString(p, StandardCharsets.UTF_8)
+          assertTrue(read == "new\r\n")
+        }
+      },
+      test("missing parent directory raises IOException") {
+        val tmpDir = Files.createTempDirectory("csvzen-missing-")
+        try {
+          val missing = tmpDir.resolve("does-not-exist").resolve("out.csv")
+          val ex      = scala.util.Try(CsvWriter.open(missing, CsvConfig.default))
+          val failed  = ex.isFailure
+          val isIoExc = ex.failed.toOption.exists(_.isInstanceOf[java.io.IOException])
+          assertTrue(failed, isIoExc)
+        } finally { val _ = Files.deleteIfExists(tmpDir) }
+      },
+    )
+
+  // Each shipped primitive round-tripped through a real file.
+  private final case class P1(v: String) derives CsvRowEncoder
+  private final case class P2(v: Int) derives CsvRowEncoder
+  private final case class P3(v: Long) derives CsvRowEncoder
+  private final case class P4(v: Short) derives CsvRowEncoder
+  private final case class P5(v: Byte) derives CsvRowEncoder
+  private final case class P6(v: Boolean) derives CsvRowEncoder
+  private final case class P7(v: Char) derives CsvRowEncoder
+  private final case class P8(v: Float) derives CsvRowEncoder
+  private final case class P9(v: Double) derives CsvRowEncoder
+  private final case class P10(v: BigInt) derives CsvRowEncoder
+  private final case class P11(v: BigDecimal) derives CsvRowEncoder
+  private final case class P12(v: UUID) derives CsvRowEncoder
+  private final case class P13(v: Currency) derives CsvRowEncoder
+  private final case class P14(v: DayOfWeek) derives CsvRowEncoder
+  private final case class P15(v: Duration) derives CsvRowEncoder
+  private final case class P16(v: Instant) derives CsvRowEncoder
+  private final case class P17(v: LocalDate) derives CsvRowEncoder
+  private final case class P18(v: LocalDateTime) derives CsvRowEncoder
+  private final case class P19(v: LocalTime) derives CsvRowEncoder
+  private final case class P20(v: Month) derives CsvRowEncoder
+  private final case class P21(v: MonthDay) derives CsvRowEncoder
+  private final case class P22(v: OffsetDateTime) derives CsvRowEncoder
+  private final case class P23(v: OffsetTime) derives CsvRowEncoder
+  private final case class P24(v: Period) derives CsvRowEncoder
+  private final case class P25(v: Year) derives CsvRowEncoder
+  private final case class P26(v: YearMonth) derives CsvRowEncoder
+  private final case class P27(v: ZoneId) derives CsvRowEncoder
+  private final case class P28(v: ZoneOffset) derives CsvRowEncoder
+  private final case class P29(v: ZonedDateTime) derives CsvRowEncoder
+
+  private def parseFirstCell[A](row: A)(using enc: CsvRowEncoder[A]): String = {
+    val (s, _) = writeAndRead()(_.writeRow(row))
+    TestCsvReader.parse(s).head.head
+  }
+
+  private val roundTripAllEncoders =
+    suite("round-trip each shipped encoder through a real file")(
+      test("String (with specials)") {
+        val cell = parseFirstCell(P1("a,\"b\nc"))
+        assertTrue(cell == "a,\"b\nc")
+      },
+      test("Int / Long / Short / Byte") {
+        val intVal   = Integer.parseInt(parseFirstCell(P2(Int.MaxValue)))
+        val longVal  = java.lang.Long.parseLong(parseFirstCell(P3(Long.MinValue)))
+        val shortVal = java.lang.Short.parseShort(parseFirstCell(P4(Short.MaxValue)))
+        val byteVal  = java.lang.Byte.parseByte(parseFirstCell(P5((-1).toByte)))
+        assertTrue(
+          intVal == Int.MaxValue,
+          longVal == Long.MinValue,
+          shortVal == Short.MaxValue,
+          byteVal == (-1).toByte,
+        )
+      },
+      test("Boolean / Char") {
+        val boolCell = parseFirstCell(P6(true)).toBoolean
+        val charCell = parseFirstCell(P7('z'))
+        assertTrue(boolCell, charCell == "z")
+      },
+      test("Float / Double") {
+        val fv = java.lang.Float.parseFloat(parseFirstCell(P8(1.5f)))
+        val dv = java.lang.Double.parseDouble(parseFirstCell(P9(math.Pi)))
+        assertTrue(fv == 1.5f, dv == math.Pi)
+      },
+      test("BigInt / BigDecimal") {
+        val bi     = BigInt("123456789012345678901234567890")
+        val bd     = BigDecimal("3.14159265358979323846")
+        val biBack = BigInt(parseFirstCell(P10(bi)))
+        val bdBack = BigDecimal(parseFirstCell(P11(bd)))
+        assertTrue(biBack == bi, bdBack == bd)
+      },
+      test("UUID / Currency") {
+        val u       = UUID.randomUUID()
+        val uBack   = UUID.fromString(parseFirstCell(P12(u)))
+        val curCell = parseFirstCell(P13(Currency.getInstance("EUR")))
+        assertTrue(uBack == u, curCell == "EUR")
+      },
+      test("DayOfWeek / Month / Duration") {
+        val dw     = DayOfWeek.FRIDAY
+        val m      = Month.APRIL
+        val d      = Duration.ofSeconds(125, 500)
+        val dwBack = DayOfWeek.valueOf(parseFirstCell(P14(dw)))
+        val mBack  = Month.valueOf(parseFirstCell(P20(m)))
+        val dBack  = Duration.parse(parseFirstCell(P15(d)))
+        assertTrue(dwBack == dw, mBack == m, dBack == d)
+      },
+      test("Instant / LocalDate / LocalDateTime / LocalTime") {
+        val i      = Instant.parse("2026-04-24T12:00:00.123456789Z")
+        val ld     = LocalDate.of(2026, 4, 24)
+        val dt     = LocalDateTime.of(2026, 4, 24, 12, 0, 0, 123456789)
+        val lt     = LocalTime.of(12, 0, 0, 123456789)
+        val iBack  = Instant.parse(parseFirstCell(P16(i)))
+        val ldBack = LocalDate.parse(parseFirstCell(P17(ld)))
+        val dtBack = LocalDateTime.parse(parseFirstCell(P18(dt)))
+        val ltBack = LocalTime.parse(parseFirstCell(P19(lt)))
+        assertTrue(iBack == i, ldBack == ld, dtBack == dt, ltBack == lt)
+      },
+      test("MonthDay / Period / Year / YearMonth") {
+        val md     = MonthDay.of(4, 24)
+        val p      = Period.of(1, 2, 3)
+        val y      = Year.of(2026)
+        val ym     = YearMonth.of(2026, 4)
+        val mdBack = MonthDay.parse(parseFirstCell(P21(md)))
+        val pBack  = Period.parse(parseFirstCell(P24(p)))
+        val yBack  = Year.parse(parseFirstCell(P25(y)))
+        val ymBack = YearMonth.parse(parseFirstCell(P26(ym)))
+        assertTrue(mdBack == md, pBack == p, yBack == y, ymBack == ym)
+      },
+      test("OffsetDateTime / OffsetTime") {
+        val odt     = OffsetDateTime.parse("2026-04-24T12:00:00+02:00")
+        val ot      = OffsetTime.parse("12:00:00+02:00")
+        val odtBack = OffsetDateTime.parse(parseFirstCell(P22(odt)))
+        val otBack  = OffsetTime.parse(parseFirstCell(P23(ot)))
+        assertTrue(odtBack == odt, otBack == ot)
+      },
+      test("ZoneId / ZoneOffset / ZonedDateTime") {
+        val z       = ZoneId.of("Europe/Paris")
+        val zo      = ZoneOffset.ofHours(-5)
+        val zdt     = ZonedDateTime.parse("2026-04-24T12:00:00+02:00[Europe/Paris]")
+        val zBack   = ZoneId.of(parseFirstCell(P27(z)))
+        val zoBack  = ZoneOffset.of(parseFirstCell(P28(zo)))
+        val zdtBack = ZonedDateTime.parse(parseFirstCell(P29(zdt)))
+        assertTrue(zBack == z, zoBack == zo, zdtBack == zdt)
+      },
+    )
+
+  private val charsetAndOpenOptionsSpec =
+    suite("CsvWriter.open charset and open-options")(
+      test("ISO-8859-1: non-ASCII characters are encoded in that charset, not UTF-8") {
+        withTmpFile { p =>
+          val latin1   = java.nio.charset.Charset.forName("ISO-8859-1")
+          val w        = CsvWriter.open(p, CsvConfig.default, latin1)
+          try w.writeRow(_.emitString("café"))
+          finally w.close()
+          val bytes    = Files.readAllBytes(p)
+          val expected = "café\r\n".getBytes(latin1)
+          val matches  = bytes.sameElements(expected)
+          assertTrue(matches)
+        }
+      },
+      test("APPEND option appends to existing content") {
+        withTmpFile { p =>
+          Files.writeString(p, "existing\r\n", StandardCharsets.UTF_8)
+          val w    = CsvWriter.open(
+            p,
+            CsvConfig.default,
+            StandardCharsets.UTF_8,
+            java.nio.file.StandardOpenOption.APPEND,
+          )
+          try w.writeRow(_.emitString("added"))
+          finally w.close()
+          val read = Files.readString(p, StandardCharsets.UTF_8)
+          assertTrue(read == "existing\r\nadded\r\n")
+        }
+      },
+    )
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("CsvFileWriter")(
+      utf8Spec,
+      terminatorSpec,
+      emptyAndHeaderSpec,
+      largeFileSpec,
+      quotingRoundTripSpec,
+      overwriteAndMissingDirSpec,
+      charsetAndOpenOptionsSpec,
+      roundTripAllEncoders,
+    )
+}

--- a/core/src/test/scala/com/guizmaii/csvzen/core/CsvRowEncoderSpec.scala
+++ b/core/src/test/scala/com/guizmaii/csvzen/core/CsvRowEncoderSpec.scala
@@ -1,0 +1,186 @@
+package com.guizmaii.csvzen.core
+
+import zio.Scope
+import zio.test.*
+
+import java.io.StringWriter
+
+object CsvRowEncoderSpec extends ZIOSpecDefault {
+
+  private def writeRow[A](a: A)(using enc: CsvRowEncoder[A]): String = {
+    val sw = new StringWriter
+    val w  = CsvWriter.unsafeFromWriter(sw, CsvConfig.default)
+    try w.writeRow(a)
+    finally w.close()
+    sw.toString
+  }
+
+  private def header[A](using enc: CsvRowEncoder[A]): IndexedSeq[String] = enc.headerNames
+
+  private final case class One(a: Int) derives CsvRowEncoder
+  private final case class Two(a: Int, b: String) derives CsvRowEncoder
+  private final case class Five(a: Int, b: String, c: Boolean, d: Long, e: Option[String]) derives CsvRowEncoder
+  private final case class Ten(
+    a: Int,
+    b: Int,
+    c: Int,
+    d: Int,
+    e: Int,
+    f: Int,
+    g: Int,
+    h: Int,
+    i: Int,
+    j: Int,
+  ) derives CsvRowEncoder
+
+  // 22-field case class — the classic Scala arity cap.
+  private final case class Twenty2(
+    a: Int,
+    b: Int,
+    c: Int,
+    d: Int,
+    e: Int,
+    f: Int,
+    g: Int,
+    h: Int,
+    i: Int,
+    j: Int,
+    k: Int,
+    l: Int,
+    m: Int,
+    n: Int,
+    o: Int,
+    p: Int,
+    q: Int,
+    r: Int,
+    s: Int,
+    t: Int,
+    u: Int,
+    v: Int,
+  ) derives CsvRowEncoder
+
+  private final case class Weird(`user-id`: Int, `日本語`: String) derives CsvRowEncoder
+
+  private val arityHeadersSpec =
+    suite("header derivation")(
+      test("arity 1")(assertTrue(header[One] == IndexedSeq("a"))),
+      test("arity 2")(assertTrue(header[Two] == IndexedSeq("a", "b"))),
+      test("arity 5")(assertTrue(header[Five] == IndexedSeq("a", "b", "c", "d", "e"))),
+      test("arity 10") {
+        assertTrue(header[Ten] == IndexedSeq("a", "b", "c", "d", "e", "f", "g", "h", "i", "j"))
+      },
+      test("arity 22") {
+        val expected = IndexedSeq(
+          "a",
+          "b",
+          "c",
+          "d",
+          "e",
+          "f",
+          "g",
+          "h",
+          "i",
+          "j",
+          "k",
+          "l",
+          "m",
+          "n",
+          "o",
+          "p",
+          "q",
+          "r",
+          "s",
+          "t",
+          "u",
+          "v",
+        )
+        assertTrue(header[Twenty2] == expected)
+      },
+      test("preserves backticked and unicode labels") {
+        assertTrue(header[Weird] == IndexedSeq("user-id", "日本語"))
+      },
+    )
+
+  private val encodeArityRoundTrip =
+    suite("encode over arities")(
+      test("arity 1 emits single field") {
+        assertTrue(writeRow(One(42)) == "42\r\n")
+      },
+      test("arity 5 with Option") {
+        assertTrue(
+          writeRow(Five(1, "x", true, 99L, Some("y"))) == "1,x,true,99,y\r\n",
+          writeRow(Five(1, "x", false, 99L, None)) == "1,x,false,99,\r\n",
+        )
+      },
+      test("arity 22 fills in order") {
+        val v   = Twenty2(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22)
+        val out = writeRow(v)
+        assertTrue(out == "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22\r\n")
+      },
+      test("weird labels emit correct header (label with '-' is quoted in header? no — no escape chars)") {
+        val sw = new StringWriter
+        val w  = CsvWriter.unsafeFromWriter(sw, CsvConfig.default)
+        try w.writeHeader[Weird]()
+        finally w.close()
+        assertTrue(sw.toString == "user-id,日本語\r\n")
+      },
+    )
+
+  // Codec path should be byte-identical to hand-written escape-hatch.
+  private val codecMatchesHandWritten =
+    suite("codec path matches escape hatch")(
+      test("Five identical output through both paths") {
+        val v   = Five(7, "a,b", true, 123L, Some("q\"r"))
+        val sw1 = new StringWriter
+        val w1  = CsvWriter.unsafeFromWriter(sw1, CsvConfig.default)
+        try w1.writeRow(v)
+        finally w1.close()
+        val sw2 = new StringWriter
+        val w2  = CsvWriter.unsafeFromWriter(sw2, CsvConfig.default)
+        try
+          w2.writeRow { e =>
+            e.emitInt(v.a)
+            e.emitString(v.b)
+            e.emitBoolean(v.c)
+            e.emitLong(v.d)
+            v.e match {
+              case Some(s) => e.emitString(s)
+              case None    => e.emitEmpty()
+            }
+          }
+        finally w2.close()
+        assertTrue(sw1.toString == sw2.toString)
+      }
+    )
+
+  // Compile-time failure tests via scala.compiletime.testing. We pin an error-message
+  // substring so that unrelated compile failures (typos in the snippet, renames in the
+  // library) don't accidentally turn these green.
+  private val negativeCompile =
+    suite("derivation fails cleanly for unsupported shapes")(
+      test("missing CsvFieldEncoder for a field type") {
+        // Define the unknown field type inside the quoted snippet so the outer
+        // compiler doesn't see an unused local definition.
+        val err      = scala.compiletime.testing.typeCheckErrors(
+          """
+          final class UnknownFieldType(val x: Int)
+          final case class BadRow(c: UnknownFieldType) derives CsvRowEncoder
+          """
+        )
+        val mentions = err.exists(_.message.contains("CsvFieldEncoder"))
+        assertTrue(err.nonEmpty, mentions)
+      },
+      test("non-product type (no Mirror.ProductOf)") {
+        val err      = scala.compiletime.testing.typeCheckErrors(
+          """
+          CsvRowEncoder.derived[List[Int]]
+          """
+        )
+        val mentions = err.exists(e => e.message.contains("Product") || e.message.contains("Mirror"))
+        assertTrue(err.nonEmpty, mentions)
+      },
+    )
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("CsvRowEncoder")(arityHeadersSpec, encodeArityRoundTrip, codecMatchesHandWritten, negativeCompile)
+}

--- a/core/src/test/scala/com/guizmaii/csvzen/core/CsvRowEncoderSpec.scala
+++ b/core/src/test/scala/com/guizmaii/csvzen/core/CsvRowEncoderSpec.scala
@@ -153,31 +153,39 @@ object CsvRowEncoderSpec extends ZIOSpecDefault {
       }
     )
 
-  // Compile-time failure tests via scala.compiletime.testing. We pin an error-message
-  // substring so that unrelated compile failures (typos in the snippet, renames in the
-  // library) don't accidentally turn these green.
+  // Compile-time failure tests via scala.compiletime.testing. We pin the exact full
+  // error message and assert error count == 1 so that unrelated compile failures
+  // (typos in the snippet, renames in the library) don't accidentally turn these green.
+  // Trade-off: the messages are produced by dotc itself, so a Scala 3 minor version
+  // upgrade can rephrase them and require refreshing the strings here.
   private val negativeCompile =
     suite("derivation fails cleanly for unsupported shapes")(
       test("missing CsvFieldEncoder for a field type") {
-        // Define the unknown field type inside the quoted snippet so the outer
-        // compiler doesn't see an unused local definition.
-        val err      = scala.compiletime.testing.typeCheckErrors(
+        val err = scala.compiletime.testing.typeCheckErrors(
           """
           final class UnknownFieldType(val x: Int)
           final case class BadRow(c: UnknownFieldType) derives CsvRowEncoder
           """
         )
-        val mentions = err.exists(_.message.contains("CsvFieldEncoder"))
-        assertTrue(err.nonEmpty, mentions)
+        assertTrue(
+          err.length == 1,
+          err.head.message ==
+            "No given instance of type com.guizmaii.csvzen.core.CsvFieldEncoder[UnknownFieldType] was found",
+        )
       },
       test("non-product type (no Mirror.ProductOf)") {
-        val err      = scala.compiletime.testing.typeCheckErrors(
+        val err = scala.compiletime.testing.typeCheckErrors(
           """
           CsvRowEncoder.derived[List[Int]]
           """
         )
-        val mentions = err.exists(e => e.message.contains("Product") || e.message.contains("Mirror"))
-        assertTrue(err.nonEmpty, mentions)
+        assertTrue(
+          err.length == 1,
+          err.head.message ==
+            "No given instance of type scala.deriving.Mirror.ProductOf[List[Int]] was found for parameter m of method derived in object CsvRowEncoder. " +
+            "Failed to synthesize an instance of type scala.deriving.Mirror.ProductOf[List[Int]]: " +
+            "class List is not a generic product because it is not a case class",
+        )
       },
     )
 

--- a/core/src/test/scala/com/guizmaii/csvzen/core/CsvRowEncoderSpec.scala
+++ b/core/src/test/scala/com/guizmaii/csvzen/core/CsvRowEncoderSpec.scala
@@ -181,6 +181,43 @@ object CsvRowEncoderSpec extends ZIOSpecDefault {
       },
     )
 
+  // Hand-built encoder via the .custom builder. Defined outside the suite so the
+  // anonymous-given form works at the case-class call sites below.
+  private final case class User(
+    id: Long,
+    email: String,
+    passwordHash: String,
+    name: String,
+  )
+  private given userPartialEncoder: CsvRowEncoder[User] =
+    CsvRowEncoder.custom(IndexedSeq("id", "name", "email")) { (u, out) =>
+      out.emitLong(u.id)
+      out.emitString(u.name)
+      out.emitString(u.email)
+    }
+
+  private val customSpec =
+    suite(".custom")(
+      test("uses the supplied header list verbatim") {
+        assertTrue(header[User] == IndexedSeq("id", "name", "email"))
+      },
+      test("encodes only the fields the lambda emits, in the lambda's order") {
+        val u = User(42L, "ada@example.com", "secret", "Ada")
+        assertTrue(writeRow(u) == "42,Ada,ada@example.com\r\n")
+      },
+      test("escaping still goes through the FieldEmitter") {
+        val u = User(1L, "a,b@example.com", "x", "he said \"hi\"")
+        assertTrue(writeRow(u) == "1,\"he said \"\"hi\"\"\",\"a,b@example.com\"\r\n")
+      },
+      test("writeHeader[A]() emits the supplied header row") {
+        val sw = new StringWriter
+        val w  = CsvWriter.unsafeFromWriter(sw, CsvConfig.default)
+        try w.writeHeader[User]()
+        finally w.close()
+        assertTrue(sw.toString == "id,name,email\r\n")
+      },
+    )
+
   override def spec: Spec[TestEnvironment & Scope, Any] =
-    suite("CsvRowEncoder")(arityHeadersSpec, encodeArityRoundTrip, codecMatchesHandWritten, negativeCompile)
+    suite("CsvRowEncoder")(arityHeadersSpec, encodeArityRoundTrip, codecMatchesHandWritten, customSpec, negativeCompile)
 }

--- a/core/src/test/scala/com/guizmaii/csvzen/core/CsvWriterSpec.scala
+++ b/core/src/test/scala/com/guizmaii/csvzen/core/CsvWriterSpec.scala
@@ -101,12 +101,12 @@ object CsvWriterSpec extends ZIOSpecDefault {
         assertTrue(out == "")
       },
       test("iterates a List in order") {
-        val out = writeToString()(_.writeAll(List(Pair(10, "x"))))
-        assertTrue(out == "10,x\r\n")
+        val out = writeToString()(_.writeAll(List(Pair(10, "x"), Pair(20, "y"), Pair(30, "z"))))
+        assertTrue(out == "10,x\r\n20,y\r\n30,z\r\n")
       },
       test("iterates a LazyList in order") {
-        val out = writeToString()(_.writeAll(LazyList(Pair(7, "q"))))
-        assertTrue(out == "7,q\r\n")
+        val out = writeToString()(_.writeAll(LazyList(Pair(7, "q"), Pair(8, "r"), Pair(9, "s"))))
+        assertTrue(out == "7,q\r\n8,r\r\n9,s\r\n")
       },
     )
 

--- a/core/src/test/scala/com/guizmaii/csvzen/core/CsvWriterSpec.scala
+++ b/core/src/test/scala/com/guizmaii/csvzen/core/CsvWriterSpec.scala
@@ -1,0 +1,259 @@
+package com.guizmaii.csvzen.core
+
+import zio.Scope
+import zio.test.*
+
+import java.io.StringWriter
+
+object CsvWriterSpec extends ZIOSpecDefault {
+
+  private def writeToString(config: CsvConfig = CsvConfig.default)(body: CsvWriter => Unit): String = {
+    val sw = new StringWriter
+    val w  = CsvWriter.unsafeFromWriter(sw, config)
+    try body(w)
+    finally w.close()
+    sw.toString
+  }
+
+  // --- Baseline writeRow behaviours ----------------------------------------
+
+  private val baselineWriteRowSpec =
+    suite("::writeRow (lambda escape-hatch)")(
+      test("writes plain fields separated by the delimiter and terminated by the line terminator") {
+        val out = writeToString()(_.writeRow { e => e.emitString("a"); e.emitString("b"); e.emitString("c") })
+        assertTrue(out == "a,b,c\r\n")
+      },
+      test("emits a lone line terminator for a row with no fields") {
+        val out = writeToString()(_.writeRow(_ => ()))
+        assertTrue(out == "\r\n")
+      },
+      test("writes a single-field row without a trailing delimiter") {
+        val out = writeToString()(_.writeRow(_.emitString("only")))
+        assertTrue(out == "only\r\n")
+      },
+      test("writes empty-string fields as empty cells") {
+        val out = writeToString()(_.writeRow { e => e.emitString(""); e.emitString(""); e.emitString("") })
+        assertTrue(out == ",,\r\n")
+      },
+      test("quotes a field that contains the delimiter") {
+        val out = writeToString()(_.writeRow { e => e.emitString("a,b"); e.emitString("c") })
+        assertTrue(out == "\"a,b\",c\r\n")
+      },
+      test("quotes a field that contains a double quote and doubles the internal quote") {
+        val out = writeToString()(_.writeRow(_.emitString("he said \"hi\"")))
+        assertTrue(out == "\"he said \"\"hi\"\"\"\r\n")
+      },
+      test("quotes a field that contains an LF") {
+        val out = writeToString()(_.writeRow(_.emitString("line1\nline2")))
+        assertTrue(out == "\"line1\nline2\"\r\n")
+      },
+      test("quotes a field that contains a CR") {
+        val out = writeToString()(_.writeRow(_.emitString("line1\rline2")))
+        assertTrue(out == "\"line1\rline2\"\r\n")
+      },
+      test("quotes a field that contains a CRLF") {
+        val out = writeToString()(_.writeRow(_.emitString("line1\r\nline2")))
+        assertTrue(out == "\"line1\r\nline2\"\r\n")
+      },
+      test("honours a non-default delimiter and quote character") {
+        val tsvWithHash = CsvConfig(delimiter = '\t', quoteChar = '#')
+        val out         = writeToString(tsvWithHash)(_.writeRow { e => e.emitString("a\tb"); e.emitString("c#d") })
+        assertTrue(out == "#a\tb#\t#c##d#\r\n")
+      },
+      test("honours a non-default line terminator") {
+        val lf  = CsvConfig(lineTerminator = "\n")
+        val out = writeToString(lf)(_.writeRow { e => e.emitString("a"); e.emitString("b") })
+        assertTrue(out == "a,b\n")
+      },
+    )
+
+  // --- writeHeader(IndexedSeq) --------------------------------------------
+
+  private val writeHeaderManualSpec =
+    suite("::writeHeader(IndexedSeq)")(
+      test("writes the column names joined by the delimiter and terminated by the line terminator") {
+        val out = writeToString()(_.writeHeader(IndexedSeq("name", "age", "city")))
+        assertTrue(out == "name,age,city\r\n")
+      },
+      test("escapes header names that contain specials") {
+        val out = writeToString()(_.writeHeader(IndexedSeq("first,name", "age")))
+        assertTrue(out == "\"first,name\",age\r\n")
+      },
+      test("writes nothing data-wise for an empty name list, just terminator") {
+        val out = writeToString()(_.writeHeader(IndexedSeq.empty))
+        assertTrue(out == "\r\n")
+      },
+    )
+
+  // --- writeAll (codec-driven) ---------------------------------------------
+
+  private final case class Pair(a: Int, b: String) derives CsvRowEncoder
+
+  private val writeAllSpec =
+    suite("::writeAll")(
+      test("writes one CSV row per input element, in iteration order (Vector)") {
+        val rows = Vector(Pair(1, "a"), Pair(2, "b"), Pair(3, "c"))
+        val out  = writeToString()(_.writeAll(rows))
+        assertTrue(out == "1,a\r\n2,b\r\n3,c\r\n")
+      },
+      test("writes nothing for an empty input") {
+        val out = writeToString()(_.writeAll(Vector.empty[Pair]))
+        assertTrue(out == "")
+      },
+      test("iterates a List in order") {
+        val out = writeToString()(_.writeAll(List(Pair(10, "x"))))
+        assertTrue(out == "10,x\r\n")
+      },
+      test("iterates a LazyList in order") {
+        val out = writeToString()(_.writeAll(LazyList(Pair(7, "q"))))
+        assertTrue(out == "7,q\r\n")
+      },
+    )
+
+  // --- writeRow[A] (codec path) -------------------------------------------
+
+  private final case class Mixed(
+    s: String,
+    i: Int,
+    l: Long,
+    sh: Short,
+    b: Byte,
+    bool: Boolean,
+    c: Char,
+    f: Float,
+    d: Double,
+    opt: Option[String],
+  ) derives CsvRowEncoder
+
+  private val writeRowCodecSpec =
+    suite("::writeRow[A] (codec path)")(
+      test("encodes every shipped primitive in declaration order") {
+        val m   = Mixed("hello", 42, 9999999999L, 7.toShort, (-1).toByte, true, 'x', 1.5f, 2.5, Some("opt"))
+        val out = writeToString()(_.writeRow(m))
+        assertTrue(out == "hello,42,9999999999,7,-1,true,x,1.5,2.5,opt\r\n")
+      },
+      test("encodes Option[None] as empty cell") {
+        val m   = Mixed("s", 1, 2L, 3.toShort, 4.toByte, false, 'c', 0.0f, 0.0, None)
+        val out = writeToString()(_.writeRow(m))
+        assertTrue(out == "s,1,2,3,4,false,c,0.0,0.0,\r\n")
+      },
+      test("escapes string values containing specials") {
+        final case class R(s: String) derives CsvRowEncoder
+        val out = writeToString()(_.writeRow(R("a,b")))
+        assertTrue(out == "\"a,b\"\r\n")
+      },
+    )
+
+  // --- writeHeader[A] (derived) -------------------------------------------
+
+  private val writeHeaderDerivedSpec =
+    suite("::writeHeader[A] (derived)")(
+      test("emits labels in declaration order for Pair") {
+        val out = writeToString()(_.writeHeader[Pair]())
+        assertTrue(out == "a,b\r\n")
+      },
+      test("emits labels for Mixed (10-field case class)") {
+        val out = writeToString()(_.writeHeader[Mixed]())
+        assertTrue(out == "s,i,l,sh,b,bool,c,f,d,opt\r\n")
+      },
+    )
+
+  // --- close semantics -----------------------------------------------------
+
+  private val closeSpec =
+    suite("::close")(
+      test("closes the underlying Writer") {
+        final class TrackingWriter extends java.io.Writer {
+          var closed: Int                                        = 0
+          val buf                                                = new StringBuilder
+          def write(cbuf: Array[Char], off: Int, len: Int): Unit = { val _ = buf.appendAll(cbuf, off, len) }
+          def flush(): Unit                                      = ()
+          override def close(): Unit                             = closed += 1
+        }
+        val tw = new TrackingWriter
+        val w = CsvWriter.unsafeFromWriter(tw, CsvConfig.default)
+        w.writeRow(_.emitString("x"))
+        w.close()
+        assertTrue(tw.closed == 1)
+      }
+    )
+
+  // --- non-default configs through the codec path --------------------------
+
+  private val configPropagationSpec =
+    suite("codec path honours config")(
+      test("TSV config routes through FieldEmitter's delimiter") {
+        val tsv = CsvConfig(delimiter = '\t')
+        val out = writeToString(tsv)(_.writeRow(Pair(1, "a")))
+        assertTrue(out == "1\ta\r\n")
+      },
+      test("semicolon delimiter and LF terminator") {
+        val cfg = CsvConfig(delimiter = ';', lineTerminator = "\n")
+        val out = writeToString(cfg)(_.writeRow(Pair(1, "a")))
+        assertTrue(out == "1;a\n")
+      },
+    )
+
+  // --- flush() --------------------------------------------------------------
+
+  private val flushSpec =
+    suite("::flush")(
+      test("flushes the underlying Writer") {
+        final class TrackingWriter extends java.io.Writer {
+          var flushes: Int                                       = 0
+          def write(cbuf: Array[Char], off: Int, len: Int): Unit = ()
+          def flush(): Unit                                      = flushes += 1
+          override def close(): Unit                             = ()
+        }
+        val tw = new TrackingWriter
+        val w      = CsvWriter.unsafeFromWriter(tw, CsvConfig.default)
+        w.writeRow(_.emitString("x"))
+        val before = tw.flushes
+        w.flush()
+        val after  = tw.flushes
+        w.close()
+        assertTrue(before == 0, after == 1)
+      }
+    )
+
+  // --- CsvConfig validation -------------------------------------------------
+
+  private val configValidationSpec =
+    suite("CsvConfig validation")(
+      test("rejects delimiter == quoteChar") {
+        val ex = scala.util.Try(CsvConfig(delimiter = '"', quoteChar = '"'))
+        assertTrue(ex.isFailure, ex.failed.toOption.exists(_.isInstanceOf[IllegalArgumentException]))
+      },
+      test("rejects delimiter = CR or LF") {
+        val ex1 = scala.util.Try(CsvConfig(delimiter = '\r'))
+        val ex2 = scala.util.Try(CsvConfig(delimiter = '\n'))
+        assertTrue(ex1.isFailure, ex2.isFailure)
+      },
+      test("rejects quoteChar = CR or LF") {
+        val ex1 = scala.util.Try(CsvConfig(quoteChar = '\r'))
+        val ex2 = scala.util.Try(CsvConfig(quoteChar = '\n'))
+        assertTrue(ex1.isFailure, ex2.isFailure)
+      },
+      test("rejects lineTerminator outside {\"\\n\", \"\\r\", \"\\r\\n\"}") {
+        val cases = Seq("", ";", "X", "\r\n\r\n", " ")
+        assertTrue(cases.forall(t => scala.util.Try(CsvConfig(lineTerminator = t)).isFailure))
+      },
+      test("accepts each of the three valid lineTerminators") {
+        val cases = Seq("\n", "\r", "\r\n")
+        assertTrue(cases.forall(t => scala.util.Try(CsvConfig(lineTerminator = t)).isSuccess))
+      },
+    )
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("CsvWriter")(
+      baselineWriteRowSpec,
+      writeHeaderManualSpec,
+      writeAllSpec,
+      writeRowCodecSpec,
+      writeHeaderDerivedSpec,
+      closeSpec,
+      flushSpec,
+      configPropagationSpec,
+      configValidationSpec,
+    )
+}

--- a/core/src/test/scala/com/guizmaii/csvzen/core/FieldEmitterSpec.scala
+++ b/core/src/test/scala/com/guizmaii/csvzen/core/FieldEmitterSpec.scala
@@ -36,10 +36,10 @@ object FieldEmitterSpec extends ZIOSpecDefault {
         val values = Seq(-1, -9, -10, -99, -100, -12345, Int.MinValue + 1, Int.MinValue)
         assertTrue(values.forall(v => firstField(cfg)(_.emitInt(v)) == v.toString))
       },
-      test("matches Integer.toString on a randomised sweep") {
-        val rng    = new scala.util.Random(0xc0ffee)
-        val sample = (0 until 10000).map(_ => rng.nextInt())
-        assertTrue(sample.forall(v => firstField(cfg)(_.emitInt(v)) == Integer.toString(v)))
+      test("matches Integer.toString on any Int (PBT)") {
+        check(Gen.int) { v =>
+          assertTrue(firstField(cfg)(_.emitInt(v)) == Integer.toString(v))
+        }
       },
     )
 
@@ -63,10 +63,10 @@ object FieldEmitterSpec extends ZIOSpecDefault {
         )
         assertTrue(values.forall(v => firstField(cfg)(_.emitLong(v)) == v.toString))
       },
-      test("matches java.lang.Long.toString on a randomised sweep") {
-        val rng    = new scala.util.Random(0xdeadbeefL)
-        val sample = (0 until 10000).map(_ => rng.nextLong())
-        assertTrue(sample.forall(v => firstField(cfg)(_.emitLong(v)) == java.lang.Long.toString(v)))
+      test("matches java.lang.Long.toString on any Long (PBT)") {
+        check(Gen.long) { v =>
+          assertTrue(firstField(cfg)(_.emitLong(v)) == java.lang.Long.toString(v))
+        }
       },
     )
 

--- a/core/src/test/scala/com/guizmaii/csvzen/core/FieldEmitterSpec.scala
+++ b/core/src/test/scala/com/guizmaii/csvzen/core/FieldEmitterSpec.scala
@@ -1,0 +1,270 @@
+package com.guizmaii.csvzen.core
+
+import zio.Scope
+import zio.test.*
+
+import java.io.StringWriter
+
+object FieldEmitterSpec extends ZIOSpecDefault {
+
+  private def emitWith(config: CsvConfig)(body: FieldEmitter => Unit): String = {
+    val sw = new StringWriter
+    val w  = CsvWriter.unsafeFromWriter(sw, config)
+    try w.writeRow(body)
+    finally w.close()
+    sw.toString
+  }
+
+  private def firstField(config: CsvConfig)(body: FieldEmitter => Unit): String = {
+    val full = emitWith(config)(body)
+    // strip line terminator
+    full.stripSuffix(config.lineTerminator)
+  }
+
+  private val cfg = CsvConfig.default
+
+  private val emitIntSpec =
+    suite("::emitInt")(
+      test("writes 0") {
+        assertTrue(firstField(cfg)(_.emitInt(0)) == "0")
+      },
+      test("writes positive values") {
+        val values = Seq(1, 9, 10, 99, 100, 12345, Int.MaxValue - 1, Int.MaxValue)
+        assertTrue(values.forall(v => firstField(cfg)(_.emitInt(v)) == v.toString))
+      },
+      test("writes negative values") {
+        val values = Seq(-1, -9, -10, -99, -100, -12345, Int.MinValue + 1, Int.MinValue)
+        assertTrue(values.forall(v => firstField(cfg)(_.emitInt(v)) == v.toString))
+      },
+      test("matches Integer.toString on a randomised sweep") {
+        val rng    = new scala.util.Random(0xc0ffee)
+        val sample = (0 until 10000).map(_ => rng.nextInt())
+        assertTrue(sample.forall(v => firstField(cfg)(_.emitInt(v)) == Integer.toString(v)))
+      },
+    )
+
+  private val emitLongSpec =
+    suite("::emitLong")(
+      test("writes 0L") {
+        assertTrue(firstField(cfg)(_.emitLong(0L)) == "0")
+      },
+      test("writes boundary values") {
+        val values = Seq(
+          1L,
+          -1L,
+          10L,
+          -10L,
+          99L,
+          -99L,
+          Int.MaxValue.toLong + 1L,
+          Int.MinValue.toLong - 1L,
+          Long.MaxValue,
+          Long.MinValue,
+        )
+        assertTrue(values.forall(v => firstField(cfg)(_.emitLong(v)) == v.toString))
+      },
+      test("matches java.lang.Long.toString on a randomised sweep") {
+        val rng    = new scala.util.Random(0xdeadbeefL)
+        val sample = (0 until 10000).map(_ => rng.nextLong())
+        assertTrue(sample.forall(v => firstField(cfg)(_.emitLong(v)) == java.lang.Long.toString(v)))
+      },
+    )
+
+  private val emitShortSpec =
+    suite("::emitShort")(
+      test("exhaustive over full Short range") {
+        val ok = (Short.MinValue.toInt to Short.MaxValue.toInt).forall { iv =>
+          val v = iv.toShort
+          firstField(cfg)(_.emitShort(v)) == v.toString
+        }
+        assertTrue(ok)
+      }
+    )
+
+  private val emitByteSpec =
+    suite("::emitByte")(
+      test("exhaustive over full Byte range") {
+        val ok = (Byte.MinValue.toInt to Byte.MaxValue.toInt).forall { iv =>
+          val v = iv.toByte
+          firstField(cfg)(_.emitByte(v)) == v.toString
+        }
+        assertTrue(ok)
+      }
+    )
+
+  private val emitBooleanSpec =
+    suite("::emitBoolean")(
+      test("writes true") {
+        assertTrue(firstField(cfg)(_.emitBoolean(true)) == "true")
+      },
+      test("writes false") {
+        assertTrue(firstField(cfg)(_.emitBoolean(false)) == "false")
+      },
+    )
+
+  private val emitFloatSpec =
+    suite("::emitFloat")(
+      test("matches Float.toString on key values") {
+        val values =
+          Seq(
+            0.0f,
+            -0.0f,
+            1.0f,
+            -1.0f,
+            Float.MinPositiveValue,
+            Float.MinValue,
+            Float.MaxValue,
+            math.Pi.toFloat,
+            math.E.toFloat,
+            Float.PositiveInfinity,
+            Float.NegativeInfinity,
+            Float.NaN
+          )
+        assertTrue(values.forall(v => firstField(cfg)(_.emitFloat(v)) == java.lang.Float.toString(v)))
+      }
+    )
+
+  private val emitDoubleSpec =
+    suite("::emitDouble")(
+      test("matches Double.toString on key values") {
+        val values =
+          Seq(
+            0.0,
+            -0.0,
+            1.0,
+            -1.0,
+            Double.MinPositiveValue,
+            Double.MinValue,
+            Double.MaxValue,
+            math.Pi,
+            math.E,
+            Double.PositiveInfinity,
+            Double.NegativeInfinity,
+            Double.NaN,
+            1.23456789e10,
+            -1.23456789e-10
+          )
+        assertTrue(values.forall(v => firstField(cfg)(_.emitDouble(v)) == java.lang.Double.toString(v)))
+      }
+    )
+
+  private val emitCharSpec =
+    suite("::emitChar")(
+      test("writes a plain ASCII char verbatim") {
+        assertTrue(firstField(cfg)(_.emitChar('a')) == "a")
+      },
+      test("quotes and doubles the quote char") {
+        assertTrue(firstField(cfg)(_.emitChar('"')) == "\"\"\"\"")
+      },
+      test("quotes the delimiter char") {
+        assertTrue(firstField(cfg)(_.emitChar(',')) == "\",\"")
+      },
+      test("quotes CR") {
+        assertTrue(firstField(cfg)(_.emitChar('\r')) == "\"\r\"")
+      },
+      test("quotes LF") {
+        assertTrue(firstField(cfg)(_.emitChar('\n')) == "\"\n\"")
+      },
+      test("writes a non-ASCII BMP char verbatim") {
+        assertTrue(firstField(cfg)(_.emitChar('é')) == "é")
+      },
+    )
+
+  private def stringMatrix(config: CsvConfig): TestResult = {
+    val cases: Seq[(String, String)] = Seq(
+      ""           -> "",
+      "hello"      -> "hello",
+      "a,b"        -> s"${config.quoteChar}a,b${config.quoteChar}",
+      "a\"b"       -> s"${config.quoteChar}a${config.quoteChar}${config.quoteChar}b${config.quoteChar}",
+      "a\nb"       -> s"${config.quoteChar}a\nb${config.quoteChar}",
+      "a\rb"       -> s"${config.quoteChar}a\rb${config.quoteChar}",
+      "a\r\nb"     -> s"${config.quoteChar}a\r\nb${config.quoteChar}",
+      "\"at start" -> s"${config.quoteChar}${config.quoteChar}${config.quoteChar}at start${config.quoteChar}",
+      "at end\""   -> s"${config.quoteChar}at end${config.quoteChar}${config.quoteChar}${config.quoteChar}",
+    )
+    val defaults                     = cases.filter { case (in, _) =>
+      if (config.delimiter == ',' && config.quoteChar == '"') true
+      else !in.contains(',') && !in.contains('"')
+    }
+    assertTrue(defaults.forall { case (in, expected) => firstField(config)(_.emitString(in)) == expected })
+  }
+
+  private val emitStringSpec =
+    suite("::emitString")(
+      test("default config: matrix of escape cases") {
+        stringMatrix(CsvConfig.default)
+      },
+      test("TSV+hash config quotes delimiter/quote correctly") {
+        val tsv = CsvConfig(delimiter = '\t', quoteChar = '#')
+        val out = firstField(tsv)(_.emitString("a\tb#c"))
+        assertTrue(out == "#a\tb##c#")
+      },
+      test("LF-only terminator: string values pass through unchanged") {
+        val lf = CsvConfig(lineTerminator = "\n")
+        assertTrue(firstField(lf)(_.emitString("plain")) == "plain")
+      },
+      test("fast path on long plain string is identity") {
+        val big = "a" * 100000
+        assertTrue(firstField(cfg)(_.emitString(big)) == big)
+      },
+      test("preserves unicode (CJK and emoji)") {
+        val s = "日本語 🎉 →"
+        assertTrue(firstField(cfg)(_.emitString(s)) == s)
+      },
+      test("handles special at position 0, middle, end") {
+        val inputs = Seq("\"abc", "ab\"cd", "abc\"")
+        val outs   = inputs.map(s => firstField(cfg)(_.emitString(s)))
+        assertTrue(outs == Seq("\"\"\"abc\"", "\"ab\"\"cd\"", "\"abc\"\"\""))
+      },
+    )
+
+  private val emitEmptySpec =
+    suite("::emitEmpty")(
+      test("two in a row produce a lone delimiter") {
+        val out = firstField(cfg) { e => e.emitEmpty(); e.emitEmpty() }
+        assertTrue(out == ",")
+      },
+      test("one on a row produces an empty cell") {
+        val out = firstField(cfg)(_.emitEmpty())
+        assertTrue(out == "")
+      },
+    )
+
+  private val delimiterPlacementSpec =
+    suite("delimiter placement")(
+      test("no delimiter before first field") {
+        assertTrue(firstField(cfg)(_.emitInt(1)) == "1")
+      },
+      test("exactly one delimiter between two emits of different types") {
+        val pairs: Seq[(String, FieldEmitter => Unit)] = Seq(
+          "1,2"    -> (e => { e.emitInt(1); e.emitInt(2) }),
+          "1,a"    -> (e => { e.emitInt(1); e.emitString("a") }),
+          "a,1"    -> (e => { e.emitString("a"); e.emitInt(1) }),
+          ",1"     -> (e => { e.emitEmpty(); e.emitInt(1) }),
+          "1,"     -> (e => { e.emitInt(1); e.emitEmpty() }),
+          "c,true" -> (e => { e.emitChar('c'); e.emitBoolean(true) }),
+          "1,2"    -> (e => { e.emitShort(1.toShort); e.emitByte(2.toByte) }),
+        )
+        assertTrue(pairs.forall { case (exp, body) => firstField(cfg)(body) == exp })
+      },
+      test("three-field row") {
+        val out = firstField(cfg) { e => e.emitInt(1); e.emitString("a"); e.emitBoolean(false) }
+        assertTrue(out == "1,a,false")
+      },
+    )
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("FieldEmitter")(
+      emitIntSpec,
+      emitLongSpec,
+      emitShortSpec,
+      emitByteSpec,
+      emitBooleanSpec,
+      emitFloatSpec,
+      emitDoubleSpec,
+      emitCharSpec,
+      emitStringSpec,
+      emitEmptySpec,
+      delimiterPlacementSpec,
+    )
+}

--- a/core/src/test/scala/com/guizmaii/csvzen/core/TestCsvReader.scala
+++ b/core/src/test/scala/com/guizmaii/csvzen/core/TestCsvReader.scala
@@ -1,0 +1,65 @@
+package com.guizmaii.csvzen.core
+
+/**
+ * Minimal RFC 4180 CSV reader used exclusively to round-trip test output.
+ * Not part of the public API. Not optimised. Handles `\r\n` and `\n` line endings
+ * indiscriminately since we exercise both terminator configs against it.
+ */
+object TestCsvReader {
+
+  def parse(input: String, config: CsvConfig = CsvConfig.default): Vector[Vector[String]] = {
+    val delimiter = config.delimiter
+    val quoteChar = config.quoteChar
+    val rows      = Vector.newBuilder[Vector[String]]
+    var row       = Vector.newBuilder[String]
+    val cell      = new StringBuilder
+    var i         = 0
+    val n         = input.length
+    var inQuotes  = false
+    var rowHasAny = false
+
+    def endCell(): Unit = {
+      row += cell.toString
+      cell.setLength(0)
+      rowHasAny = true
+    }
+    def endRow(): Unit  = {
+      // Always flush at least one cell per row, so a bare terminator maps to Vector("").
+      endCell()
+      rows += row.result()
+      row = Vector.newBuilder[String]
+      rowHasAny = false
+    }
+
+    while (i < n) {
+      val c = input.charAt(i)
+      if (inQuotes) {
+        if (c == quoteChar) {
+          if (i + 1 < n && input.charAt(i + 1) == quoteChar) {
+            cell.append(quoteChar); i += 2
+          } else {
+            inQuotes = false; i += 1
+          }
+        } else {
+          cell.append(c); i += 1
+        }
+      } else if (c == quoteChar) {
+        inQuotes = true
+        rowHasAny = true
+        i += 1
+      } else if (c == delimiter) {
+        endCell(); i += 1
+      } else if (c == '\r' && i + 1 < n && input.charAt(i + 1) == '\n') {
+        endRow(); i += 2
+      } else if (c == '\n') {
+        endRow(); i += 1
+      } else {
+        cell.append(c)
+        rowHasAny = true
+        i += 1
+      }
+    }
+    if (rowHasAny || cell.length > 0) endRow()
+    rows.result()
+  }
+}

--- a/docs/superpowers/specs/2026-04-24-csvzen-design.md
+++ b/docs/superpowers/specs/2026-04-24-csvzen-design.md
@@ -1,0 +1,397 @@
+# csvzen — Design
+
+**Date:** 2026-04-24
+**Status:** Implemented in v0.1.0-SNAPSHOT
+**Scope:** v1 of `csvzen-core` (JVM-only, Scala 3, writes only)
+
+## 1. Purpose
+
+A tiny Scala-3-only library for writing CSV files in a zero-allocation, streaming fashion. Positioned explicitly against:
+
+- **scala-csv** — requires `Seq[String]` per row and relies on `.toString` for every cell.
+- **kantan-csv** — codec concept is good, but heavy implicit machinery and per-row allocations.
+- **zio-blocks `schema-csv`** — codec concept is good, but encoders `.toString` every cell, build per-row `StringBuilder`s, and drag in the full schema-reflection machinery.
+
+csvzen keeps the codec concept and strips everything else: a typed emitter that writes primitives straight to a `java.io.Writer` with no intermediate `String`s, and a minimal typeclass layer on top for case-class ergonomics.
+
+## 2. Scope & non-goals
+
+**In scope (v1):**
+
+- Writing RFC 4180-compliant CSV to a file.
+- Zero allocations in the hot path for `String`, `Int`, `Long`, `Short`, `Byte`, `Boolean`, `Char`, and `Option[None]`.
+- One documented `String` allocation per cell for `Float`, `Double`, `BigInt`, `BigDecimal`, `UUID`, `Currency`, and all shipped `java.time.*` types (same carve-out zio-blocks makes, on the same grounds: correct formatting without allocation is non-trivial).
+- Typeclass-driven row writing: `CsvRowEncoder[A]` with `derives CsvRowEncoder` for flat product types.
+- Headers derived from case-class labels.
+- An imperative escape-hatch API equivalent to the existing prior internal baseline.
+
+**Out of scope (v1):**
+
+- Reading CSV. Encoders only; no `Decoder`/`Codec` symmetry.
+- Nested case classes, sealed traits, tuples, sequences, maps.
+- `fs2` integration, ever.
+- `ZIO` integration (deferred to `csvzen-zio` — not part of v1).
+- Scala.js, Scala Native (JVM-only).
+- JMH micro-benchmarks.
+- Thread-safety (documented single-threaded).
+- Custom header names / annotation-based overrides (can be added non-breakingly later).
+
+## 3. Module layout
+
+Multi-module sbt build from the start, with a single live sub-project for v1:
+
+```
+csvzen/
+  build.sbt                 (root aggregate)
+  project/
+  core/
+    src/main/scala/com/guizmaii/csvzen/core/
+    src/main/scala/com/guizmaii/csvzen/core/internal/
+    src/test/scala/com/guizmaii/csvzen/core/
+```
+
+- Published artefact id: `csvzen-core`.
+- Base package: `com.guizmaii.csvzen.core` (public API).
+- Internals: `com.guizmaii.csvzen.core.internal` (not exported).
+- No external runtime dependencies. Stdlib + JDK only.
+- Test dependency: `dev.zio::zio-test` / `dev.zio::zio-test-sbt` (matches the broader workspace convention — no runtime impact).
+- Scala 3.3.7; max line length 120 (existing project scalafmt assumed).
+- Adding `csvzen-zio` later is a small `build.sbt` addition (`lazy val zio = project.dependsOn(core)`); no public-API changes required.
+
+## 4. Public API
+
+Everything a user sees from `csvzen-core`:
+
+```scala
+package com.guizmaii.csvzen.core
+
+import java.nio.file.Path
+import scala.deriving.Mirror
+
+final case class CsvConfig(
+  delimiter: Char = ',',
+  quoteChar: Char = '"',
+  lineTerminator: String = "\r\n",
+)
+object CsvConfig:
+  val default: CsvConfig = CsvConfig()
+
+final class CsvWriter extends AutoCloseable:
+  inline def writeRow[A](a: A)(using enc: CsvRowEncoder[A]): Unit
+  inline def writeRow(inline body: FieldEmitter => Unit): Unit
+  inline def writeHeader[A]()(using enc: CsvRowEncoder[A]): Unit
+  def writeHeader(names: IndexedSeq[String]): Unit
+  inline def writeAll[A](rows: Iterable[A])(using enc: CsvRowEncoder[A]): Unit
+  def close(): Unit
+
+object CsvWriter:
+  def open(path: Path, config: CsvConfig): CsvWriter
+
+final class FieldEmitter:
+  def emitString(s: String): Unit
+  def emitInt(i: Int): Unit
+  def emitLong(l: Long): Unit
+  def emitShort(s: Short): Unit
+  def emitByte(b: Byte): Unit
+  def emitBoolean(b: Boolean): Unit
+  def emitChar(c: Char): Unit
+  def emitFloat(f: Float): Unit
+  def emitDouble(d: Double): Unit
+  def emitEmpty(): Unit
+
+trait CsvFieldEncoder[-A]:
+  def encode(a: A, out: FieldEmitter): Unit
+
+object CsvFieldEncoder:
+  given CsvFieldEncoder[String]
+  given CsvFieldEncoder[Int]
+  given CsvFieldEncoder[Long]
+  given CsvFieldEncoder[Short]
+  given CsvFieldEncoder[Byte]
+  given CsvFieldEncoder[Boolean]
+  given CsvFieldEncoder[Char]
+  given CsvFieldEncoder[Float]
+  given CsvFieldEncoder[Double]
+  given CsvFieldEncoder[BigInt]
+  given CsvFieldEncoder[BigDecimal]
+  given CsvFieldEncoder[java.util.UUID]
+  given CsvFieldEncoder[java.util.Currency]
+  given CsvFieldEncoder[java.time.DayOfWeek]
+  given CsvFieldEncoder[java.time.Duration]
+  given CsvFieldEncoder[java.time.Instant]
+  given CsvFieldEncoder[java.time.LocalDate]
+  given CsvFieldEncoder[java.time.LocalDateTime]
+  given CsvFieldEncoder[java.time.LocalTime]
+  given CsvFieldEncoder[java.time.Month]
+  given CsvFieldEncoder[java.time.MonthDay]
+  given CsvFieldEncoder[java.time.OffsetDateTime]
+  given CsvFieldEncoder[java.time.OffsetTime]
+  given CsvFieldEncoder[java.time.Period]
+  given CsvFieldEncoder[java.time.Year]
+  given CsvFieldEncoder[java.time.YearMonth]
+  given CsvFieldEncoder[java.time.ZoneId]
+  given CsvFieldEncoder[java.time.ZoneOffset]
+  given CsvFieldEncoder[java.time.ZonedDateTime]
+  given [A](using CsvFieldEncoder[A]): CsvFieldEncoder[Option[A]]
+
+trait CsvRowEncoder[-A]:
+  def headerNames: IndexedSeq[String]
+  def encode(a: A, out: FieldEmitter): Unit
+
+object CsvRowEncoder:
+  inline def derived[A](using m: Mirror.ProductOf[A]): CsvRowEncoder[A]
+```
+
+**Typical usage:**
+
+```scala
+import com.guizmaii.csvzen.core.*
+import scala.util.Using
+
+final case class Person(name: String, age: Int, email: Option[String])
+  derives CsvRowEncoder
+
+Using.resource(CsvWriter.open(path, CsvConfig.default)) { w =>
+  w.writeHeader[Person]()
+  w.writeAll(people)
+}
+```
+
+## 5. `FieldEmitter` internals
+
+A single `FieldEmitter` instance per `CsvWriter`, reused for every row.
+
+**State (all primitives or interned strings — no per-row allocation):**
+
+- `out: java.io.Writer` — the sink.
+- `delimiter: Int`, `quoteChar: Int`, `lineTerminator: String` — unpacked from `CsvConfig` in the constructor so each emit is a direct field read.
+- `first: Boolean` — "is this the first field of the current row?".
+- `scratch: Array[Char]` of length 20 — enough for `Long.MinValue` = `-9223372036854775808` (20 chars). Reused for every integer emit.
+
+**Row lifecycle (package-private, called only by `CsvWriter`):**
+
+- `beginRow(): Unit` — sets `first = true`.
+- `endRow(): Unit` — writes `lineTerminator`.
+
+**Per-field prelude.** Every public `emitX` starts with:
+
+```scala
+if (!first) out.write(delimiter) else first = false
+```
+
+Codecs therefore never think about delimiters. Each `emitX` call is a self-contained "one field".
+
+**Integer emission (`emitInt` / `emitLong`).** Reverse-digit loop into `scratch`, then a single `out.write(scratch, offset, len)`. Special-case `Int.MinValue` / `Long.MinValue` because `-MIN_VALUE` overflows; after the sign branch, operate on a positive number.
+
+**Short / Byte.** Delegate to `emitInt`.
+
+**Boolean.** `out.write(if (b) "true" else "false")` — interned literals, no allocation.
+
+**Char.** Treated as a 1-character field with full RFC-4180 escape treatment (if `c` is a delimiter, quote, CR, or LF, wrap in quotes; double the quote if necessary).
+
+**Float / Double carve-out.** `out.write(java.lang.Float.toString(f))` / `Double.toString`. One `String` allocation per cell. Documented; optionally revisitable via Ryu-style if ever a hot spot.
+
+**String emission (fast path).** Same two-pass strategy as the prior internal baseline:
+
+1. Walk the string once to detect `needsQuoting` (delimiter, quote, CR, LF) and `hasQuote`.
+2. If `!needsQuoting`: single `out.write(s)`. Zero allocations, one Writer call.
+3. If `needsQuoting && !hasQuote`: `out.write(quoteChar)` + `out.write(s)` + `out.write(quoteChar)`. Zero allocations.
+4. If `hasQuote`: `out.write(quoteChar)` + char-by-char loop doubling quotes + `out.write(quoteChar)`. Zero allocations; multiple Writer calls only on this rare path.
+
+**`emitEmpty()`.** Just the delimiter prelude; no content. Used by `Option[None]` and any caller that wants an explicit empty cell.
+
+**Concurrency.** Not thread-safe. One writer per thread. Matches `java.io.Writer` conventions and the prior internal baseline.
+
+## 6. Codecs & derivation
+
+### 6.1 `CsvFieldEncoder[-A]`
+
+A SAM trait:
+
+```scala
+trait CsvFieldEncoder[-A]:
+  def encode(a: A, out: FieldEmitter): Unit
+```
+
+All givens are singletons delegating to the matching `FieldEmitter` method:
+
+```scala
+given CsvFieldEncoder[Int]    = (a, out) => out.emitInt(a)
+given CsvFieldEncoder[String] = (a, out) => out.emitString(a)
+// ...
+```
+
+**One-alloc carve-out set** — these encoders call `out.emitString(v.toString)` (or an equivalent canonical `String` form), matching zio-blocks' behaviour:
+
+- `BigInt`, `BigDecimal`
+- `UUID` (`UUID.toString`)
+- `Currency` (`Currency.getCurrencyCode`)
+- All shipped `java.time.*` types (their `.toString` is the ISO-8601 canonical form)
+
+**`Option[A]`:**
+
+```scala
+given [A](using inner: CsvFieldEncoder[A]): CsvFieldEncoder[Option[A]] =
+  (a, out) => a match
+    case Some(v) => inner.encode(v, out)
+    case None    => out.emitEmpty()
+```
+
+### 6.2 `CsvRowEncoder[-A]`
+
+```scala
+trait CsvRowEncoder[-A]:
+  def headerNames: IndexedSeq[String]
+  def encode(a: A, out: FieldEmitter): Unit
+```
+
+`headerNames` is computed once at derivation time, stored in a `val`, and never recomputed.
+
+### 6.3 Derivation — flat products
+
+`inline def derived[A](using m: Mirror.ProductOf[A]): CsvRowEncoder[A]` uses `scala.compiletime` primitives:
+
+1. `constValueTuple[m.MirroredElemLabels]` materialises the field labels as a compile-time `Tuple` of literal `String`s. Copied into an `Array[String]` once at derivation, wrapped as `ArraySeq` → the stored `headerNames`.
+2. `summonAll[Tuple.Map[m.MirroredElemTypes, CsvFieldEncoder]]` materialises all field encoders as a tuple of given instances. Stored in an `Array[CsvFieldEncoder[Any]]` — one allocation at derivation time, reused for every row.
+3. `encode(a, out)` casts `a` to `Product`, loops `0 until encoders.length`, and invokes `encoders(i).encode(a.productElement(i), out)`. Straight-line, monomorphic call sites → HotSpot inlines after warmup.
+
+The `productElement` + cast path *does* box primitive fields (`Int`, `Long`, etc.) on each row — this is a Scala cost of `Product` access, not something csvzen adds, and it is the remaining non-zero-alloc step in the codec path for v1. Eliminating it requires per-field unrolled accessors (approach B — see §10).
+
+**Compile-time diagnostics.** `summonAll` already produces a clean `"no given instance of type CsvFieldEncoder[Foo]"` message. We do not add custom error machinery.
+
+**Nested case classes / sealed traits / tuples / sequences.** Not supported. A nested case-class field simply fails `summonAll` at compile time because we do not provide a `CsvFieldEncoder` from a `CsvRowEncoder` (by design — silently flattening would change column counts). Users wanting a specific behaviour can write a hand-rolled `CsvFieldEncoder[X]` for their type.
+
+## 7. `CsvWriter` orchestration
+
+```scala
+final class CsvWriter private[csvzen] (out: Writer, config: CsvConfig) extends AutoCloseable:
+  private val emitter = new FieldEmitter(out, config)
+
+  inline def writeRow[A](a: A)(using enc: CsvRowEncoder[A]): Unit =
+    emitter.beginRow()
+    enc.encode(a, emitter)
+    emitter.endRow()
+
+  inline def writeRow(inline body: FieldEmitter => Unit): Unit =
+    emitter.beginRow()
+    body(emitter)
+    emitter.endRow()
+
+  inline def writeHeader[A]()(using enc: CsvRowEncoder[A]): Unit =
+    writeHeader(enc.headerNames)
+
+  def writeHeader(names: IndexedSeq[String]): Unit =
+    emitter.beginRow()
+    var i = 0
+    while i < names.length do
+      emitter.emitString(names(i))
+      i += 1
+    emitter.endRow()
+
+  inline def writeAll[A](rows: Iterable[A])(using enc: CsvRowEncoder[A]): Unit =
+    val it = rows.iterator
+    while it.hasNext do writeRow(it.next())
+
+  def close(): Unit = out.close()
+
+object CsvWriter:
+  def open(path: Path, config: CsvConfig): CsvWriter =
+    new CsvWriter(Files.newBufferedWriter(path, StandardCharsets.UTF_8), config)
+```
+
+Notes:
+
+- Only `CsvWriter.open(path, config)` is public. No `Writer`-accepting constructor; no `OutputStream + Charset`.
+- The `inline def writeRow(inline body: FieldEmitter => Unit)` escape hatch preserves the baseline's closure-erasure property: the lambda is inlined at the call site, nothing is allocated per row.
+- `writeAll` is `inline` and monomorphic in `A`; loop body is `writeRow(it.next())`, also inlined.
+
+## 8. Error handling
+
+- All `IOException`s from the underlying `Writer` propagate raw. No wrapping. No custom `CsvException`.
+- `CsvWriter.open(path, config)` can throw `IOException` (from `Files.newBufferedWriter`). Caller manages resource lifecycle (`scala.util.Using`, `try/finally`, future `ZIO.fromAutoCloseable`).
+- `close()` propagates `IOException` as usual.
+- Derivation errors are compile-time only (missing `CsvFieldEncoder`, non-`Mirror.ProductOf`).
+- No partial-row cleanup. If a codec throws mid-row, the underlying `Writer` has already received partial content; csvzen makes no all-or-nothing guarantee per row. Callers needing transactionality buffer themselves.
+
+## 9. Testing
+
+Framework: ZIO Test (`ZIOSpecDefault`), matching the broader workspace. Test naming convention: suite names use `::methodName` for methods, `.functionName` for functions; test descriptions in present tense without "should"/"must".
+
+### 9.1 `FieldEmitterSpec` — every primitive, every edge
+
+- **`emitInt`:** `0`, `1`, `-1`, `10`, `-10`, `9`, `-9`, `99`, `-99`, `100`, `-100`, `Int.MaxValue`, `Int.MinValue`, `Int.MaxValue - 1`, `Int.MinValue + 1`, plus a seeded 10 000-value randomised sweep asserted against `Integer.toString`.
+- **`emitLong`:** same pattern as `emitInt`; additionally `Int.MaxValue + 1L`, `Int.MinValue - 1L`, `Long.MaxValue`, `Long.MinValue`.
+- **`emitShort`:** exhaustive over `-32768..32767`.
+- **`emitByte`:** exhaustive over `-128..127`.
+- **`emitBoolean`:** `true` and `false`.
+- **`emitFloat` / `emitDouble`:** `0.0`, `-0.0`, `+Inf`, `-Inf`, `NaN`, subnormals, `Float.MinValue`, `Float.MaxValue`, `Math.PI`, `Math.E`, money-shaped values, each asserted against `.toString`. Documents the carve-out.
+- **`emitChar`:** all 7-bit ASCII; one BMP non-ASCII (`é`); a surrogate-pair case documented as requiring two calls.
+- **`emitString`:** matrix over `{no-specials, contains-delimiter, contains-quote, contains-LF, contains-CR, contains-CRLF, contains-multiple-specials}` × `{default, TSV+hash-quote, LF-only terminator, semicolon+single-quote}`. Empty string. Very long (100 000 chars, no specials) to exercise the fast path. Unicode (CJK, emoji with surrogate pair). Special at position 0, middle, and last.
+- **`emitEmpty`:** two in a row produce `","`; single on a row produces `""`.
+- **Delimiter-placement matrix:** for every combination of two consecutive emit kinds (emitInt+emitString, emitEmpty+emitInt, emitChar+emitBoolean, …), exactly one delimiter between them and none before the first.
+
+### 9.2 `CsvWriterSpec` — in-memory (`StringWriter`)
+
+- Every baseline writeRow test, re-expressed on the new API (the escape-hatch `writeRow(body: FieldEmitter => Unit)` has an equivalent shape).
+- Codec-driven `writeRow[A]` for case classes spanning every shipped primitive, `Option[Some]`, `Option[None]`, `Option[String]` with specials, mixed arities.
+- `writeAll[A]`: order preservation across `Vector`, `List`, `Iterator`, `LazyList`; empty iterable; single element; large batch (size chosen to stay fast in CI).
+- `writeHeader[A]()`: labels in declaration order for arities 1 / 2 / 5 / 22; labels containing specials (quoted in header).
+- `writeHeader(names)`: unchanged baseline behaviour.
+- `close()`: idempotent; underlying `Writer.close` called; post-close writes surface the Writer's error.
+- Non-default configs (TSV, semicolon, LF-only, hash-quote) propagated through the full codec path.
+
+### 9.3 `CsvFileWriterSpec` — real-file round-trips
+
+This spec exercises the full I/O + charset path. Every test uses `CsvWriter.open(tmpPath, config)`, writes, closes, and reads the file back.
+
+**Helper.** Creates a tmp file, runs a write body, closes the writer, returns `Files.readString(path, UTF_8)` and `Files.readAllBytes(path)`.
+
+- **UTF-8 correctness.** Strings containing `é`, `ü`, CJK (`日本語`), emoji (`🎉` — surrogate pair), arrow (`→`); assert bytes against hand-computed UTF-8 sequences.
+- **No BOM.** `Files.newBufferedWriter` + `UTF_8` does not write a BOM; regression guard asserts the first bytes of a non-empty file match the logical first character.
+- **Line terminators.** Default `\r\n` produces `0x0D 0x0A`; LF-only config produces `0x0A`; no stray terminator beyond what `lineTerminator` emitted.
+- **Empty file.** Open + close without writing → 0-byte file.
+- **Header-only.** `writeHeader[A]()` + close → exactly the header line + one terminator.
+- **Large file.** 100 000 rows of a mixed-type case class (primitives + `Option` + strings needing escape). Read back, split on `\r\n`, assert line count = 1 + 100 000 and first/middle/last row content.
+- **Quoting round-trip.** Every entry in the `emitString` escape matrix, but hitting disk. Read back, parse with a tiny test-only state-machine CSV reader (in test helpers, sole purpose: verifying the bytes we wrote parse back to the values we asked to write).
+- **File-overwrite semantics.** Opening on an existing file truncates; only new content remains.
+- **Missing parent directory.** `CsvWriter.open` throws `IOException`; file not created.
+- **Round-trip via every `CsvFieldEncoder`.** For each of the 28 shipped encoders: write a case class containing that field type, read the file back, parse the cell text with the canonical `String → A` parser (`Integer.parseInt`, `Instant.parse`, …), assert equal to the original. This is the "bytes mean what they claim" guarantee.
+
+### 9.4 `CsvFieldEncoderSpec` — every shipped given
+
+For each of the 28 shipped types, asserted via `FieldEmitter` + `StringWriter`:
+
+- Nominal value.
+- Boundary values where applicable (`Int.MaxValue`, `Instant.MIN` / `Instant.MAX`, `BigDecimal` with scale > 0, random and name-UUID, `Currency.getInstance("EUR"/"USD"/"JPY")`, every `DayOfWeek`, every `Month`).
+- `Option[A]` × each: `None` emits empty; `Some(v)` matches the inner encoder's output.
+
+### 9.5 `CsvRowEncoderSpec` — derivation
+
+- `derives CsvRowEncoder` compiles and produces correct `headerNames` + `encode` for arities 1 / 2 / 5 / 10 / 22.
+- Case class with every shipped field type present simultaneously.
+- Label preservation including backticked identifiers (`` `user-id` ``) and unicode labels.
+- Output byte-identical between the codec path and the equivalent hand-written escape-hatch `writeRow(lambda)`.
+- **Negative compile-time tests** via `scala.compiletime.testing.typeCheckErrors` / `compileErrors`:
+  - Nested case-class field → error identifies the missing `CsvFieldEncoder[X]`.
+  - Non-product type (e.g. `List[Int]`) → derivation fails clearly.
+  - Field of a user-defined type with no given encoder → error cites the offending field name and type.
+
+### 9.6 Out of scope for v1 tests
+
+- JMH micro-benchmarks.
+- Concurrency / thread-safety tests (single-threaded contract documented).
+- Property-based generators beyond the seeded RNG sweeps above.
+
+## 10. Future considerations
+
+- **Approach B: full-`inline` derivation.** Replace the `Array[CsvFieldEncoder[Any]]` + `productElement` machinery with a fully-unrolled inline macro that expands to `out.emitInt(a.age); out.emitString(a.name); …` at each call site. Eliminates the remaining `productElement` boxing of primitive fields and all typeclass dispatch, but costs compile time and debuggability. To be explored on an experimental branch and benchmarked against A.
+- **`csvzen-zio` module.** `CsvWriter.managed(path, config): ZIO[Scope, Throwable, CsvWriter]` plus a `ZSink[Any, Throwable, A, Nothing, Long]` factory (given `CsvRowEncoder[A]`) returning row count.
+- **Ryu-style `emitDouble`.** Eliminates the Double/Float carve-out if ever needed.
+- **Custom header-naming.** `@csvName("x")` annotation read by the derivation macro. Non-breaking.
+- **Readers.** A `CsvFieldDecoder` / `CsvRowDecoder` story mirroring the writer side. Independently shippable; no changes required to writer API.
+
+## 11. References
+
+- A prior internal CSV writer: the owns-the-Writer + inline-emit pattern and two-pass escape scan originate there.
+- zio-blocks codec inspiration: [`zio-blocks/schema-csv`](https://github.com/zio/zio-blocks/tree/main/schema-csv) — we keep the primitive codec set and escape rules, and explicitly reject the per-cell `.toString` allocations.
+- [RFC 4180](https://datatracker.ietf.org/doc/html/rfc4180).

--- a/docs/superpowers/specs/2026-04-24-csvzen-design.md
+++ b/docs/superpowers/specs/2026-04-24-csvzen-design.md
@@ -386,6 +386,40 @@ For each of the 28 shipped types, asserted via `FieldEmitter` + `StringWriter`:
 
 - **Approach B: full-`inline` derivation.** Replace the `Array[CsvFieldEncoder[Any]]` + `productElement` machinery with a fully-unrolled inline macro that expands to `out.emitInt(a.age); out.emitString(a.name); …` at each call site. Eliminates the remaining `productElement` boxing of primitive fields and all typeclass dispatch, but costs compile time and debuggability. To be explored on an experimental branch and benchmarked against A.
 - **`csvzen-zio` module.** `CsvWriter.managed(path, config): ZIO[Scope, Throwable, CsvWriter]` plus a `ZSink[Any, Throwable, A, Nothing, Long]` factory (given `CsvRowEncoder[A]`) returning row count.
+- **`csvzen-test-kit` module.** A zio-test integration providing golden-file assertions for CSV output, modelled directly on `zio-json-golden` for ergonomic parity with the rest of the ZIO ecosystem.
+
+  **Public API:**
+
+  ```scala
+  package com.guizmaii.csvzen.testkit
+
+  import com.guizmaii.csvzen.core.{ CsvConfig, CsvRowEncoder }
+  import zio.Tag
+  import zio.test.{ Gen, Sized, Spec, TestEnvironment }
+
+  final case class GoldenConfiguration(
+    relativePath: String = "",
+    sampleSize: Int      = 20,
+    csvConfig: CsvConfig = CsvConfig.default,
+  )
+  object GoldenConfiguration:
+    given default: GoldenConfiguration = GoldenConfiguration()
+
+  def goldenTest[A: Tag: CsvRowEncoder](
+    gen: Gen[Sized, A]
+  )(using GoldenConfiguration): Spec[TestEnvironment, Throwable]
+  ```
+
+  **File layout & workflow** — copied verbatim from `zio-json-golden`:
+
+  - Golden files live under `src/test/resources/golden/<relativePath>/<TypeShortName>.csv`. Type name is read from `Tag[A].tag.shortName`.
+  - First run (no golden file): the helper generates `sampleSize` rows from `gen`, encodes them through a `StringWriter`-backed `CsvWriter` (header + rows), writes the result to `<Name>_new.csv`, and fails the test with a message of the form *"No existing golden test for &lt;path&gt;. Remove `_new` from the suffix and re-run the test."* The dev removes the suffix to accept the snapshot.
+  - Subsequent runs: re-generate samples and compare to the on-disk golden. On mismatch, write `<Name>_changed.csv` next to it and fail. The dev diffs `_changed` against the original; if intended, they overwrite the original with `_changed`; if not, the test caught a regression.
+  - **No env-var / system-property update mode.** Promotion is always an explicit file-rename action by the developer.
+
+  **Sample generation.** `Gen[Sized, A].sample.forever.map(_.value).take(sampleSize.toLong).runCollect` produces a stable `Chunk[A]` (seeded by zio-test as usual). The chunk is encoded to a single CSV string via `CsvRowEncoder[A]` + `CsvConfig` from the `GoldenConfiguration`. Determinism is the gen's responsibility — same seed, same chunk, same bytes.
+
+  **Module placement.** Published as `csvzen-test-kit`, depending on `csvzen-core` and `dev.zio::zio-test`. Production code never pulls in `zio-test` — the dependency lives outside `csvzen-core`. No public-API change required in `csvzen-core`.
 - **Ryu-style `emitDouble`.** Eliminates the Double/Float carve-out if ever needed.
 - **Custom header-naming.** `@csvName("x")` annotation read by the derivation macro. Non-breaking.
 - **Readers.** A `CsvFieldDecoder` / `CsvRowDecoder` story mirroring the writer side. Independently shippable; no changes required to writer API.

--- a/docs/superpowers/specs/2026-04-24-csvzen-design.md
+++ b/docs/superpowers/specs/2026-04-24-csvzen-design.md
@@ -166,7 +166,7 @@ A single `FieldEmitter` instance per `CsvWriter`, reused for every row.
 - `out: java.io.Writer` — the sink.
 - `delimiter: Int`, `quoteChar: Int`, `lineTerminator: String` — unpacked from `CsvConfig` in the constructor so each emit is a direct field read.
 - `first: Boolean` — "is this the first field of the current row?".
-- `scratch: Array[Char]` of length 20 — enough for `Long.MinValue` = `-9223372036854775808` (20 chars). Reused for every integer emit.
+- `scratch: Array[Char]` of length 19 — enough for any signed integer's digits. `Long.MinValue`'s absolute value is `9223372036854775808` (19 digits); the sign is written separately and never enters the buffer. Reused for every integer emit.
 
 **Row lifecycle (package-private, called only by `CsvWriter`):**
 
@@ -181,7 +181,7 @@ if (!first) out.write(delimiter) else first = false
 
 Codecs therefore never think about delimiters. Each `emitX` call is a self-contained "one field".
 
-**Integer emission (`emitInt` / `emitLong`).** Reverse-digit loop into `scratch`, then a single `out.write(scratch, offset, len)`. Special-case `Int.MinValue` / `Long.MinValue` because `-MIN_VALUE` overflows; after the sign branch, operate on a positive number.
+**Integer emission (`emitInt` / `emitLong`).** Reverse-digit loop into `scratch`, then a single `out.write(scratch, offset, len)`. Digits are extracted in the **non-positive domain** (`n ≤ 0` throughout the loop): if the input is negative the leading `-` is written and `n` keeps its negative value; if positive `n` is negated once on entry. The loop then uses `('0' - n % 10).toChar` per digit. This eliminates the `Int.MinValue` / `Long.MinValue` special case — their absolute value has no positive `Int`/`Long` representation, so we never compute it. Same trick the JDK's own `java.lang.Integer.getChars` uses.
 
 **Short / Byte.** Delegate to `emitInt`.
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
 addSbtPlugin("com.timushev.sbt" % "sbt-updates"    % "0.6.4")
 addSbtPlugin("ch.epfl.scala"    % "sbt-scalafix"   % "0.14.6")
 addSbtPlugin("org.scalameta"    % "sbt-scalafmt"   % "2.5.6")
-addSbtPlugin("org.scoverage"    % "sbt-scoverage"  % "2.4.4")
 addSbtPlugin("org.typelevel"    % "sbt-tpolecat"   % "0.5.3")
 addSbtPlugin("com.github.sbt"   % "sbt-ci-release" % "1.11.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("com.timushev.sbt" % "sbt-updates"    % "0.6.4")
+addSbtPlugin("ch.epfl.scala"    % "sbt-scalafix"   % "0.14.6")
 addSbtPlugin("org.scalameta"    % "sbt-scalafmt"   % "2.5.6")
 addSbtPlugin("org.scoverage"    % "sbt-scoverage"  % "2.4.4")
 addSbtPlugin("org.typelevel"    % "sbt-tpolecat"   % "0.5.3")


### PR DESCRIPTION
## Summary

- New `csvzen-core` module: a tiny Scala 3 library for writing RFC 4180-compliant CSV to a file in a mostly-zero-allocation, streaming fashion.
- Public API: `CsvConfig`, `CsvWriter.open(path, config)`, `FieldEmitter` (typed primitives straight to `java.io.Writer`), `CsvFieldEncoder[A]` (SAM typeclass with givens for `String`, `Int`, `Long`, `Short`, `Byte`, `Boolean`, `Char`, `Float`, `Double`, `BigInt`, `BigDecimal`, `UUID`, `Currency`, every `java.time.*` type, and `Option[A]`), `CsvRowEncoder[A]` with `Mirror.ProductOf` derivation for flat case classes (`derives CsvRowEncoder`). Headers are derived from field labels.
- Multi-module sbt build: root aggregate with a single `core` subproject today, structured so a future `csvzen-zio` sibling is a drop-in.
- Exhaustive test suite (117 tests): primitive edge cases + seeded randomised sweeps, full `Short`/`Byte` ranges, RFC 4180 escape matrix across configs, derivation for arities 1/2/5/10/22 (+ unicode / backticked labels), real-file round-trips through a test-only CSV reader for every shipped encoder, UTF-8 byte sequences for emoji/CJK, and negative compile-time tests for nested/non-product types.

## Design

See [`docs/superpowers/specs/2026-04-24-csvzen-design.md`](./docs/superpowers/specs/2026-04-24-csvzen-design.md).

Positioned against scala-csv (requires `Seq[String]` per row, `.toString` everywhere), kantan-csv (heavy implicits), and zio-blocks' `schema-csv` (codec concept good, but `.toString` per cell + per-row `StringBuilder`s). csvzen keeps the codec concept and strips everything else: `FieldEmitter` writes digits straight to the `Writer` for `Int`/`Long`/`Short`/`Byte`, with a documented one-alloc carve-out for `Float`/`Double`/`BigInt`/`BigDecimal`/`UUID`/`Currency`/`java.time.*`.

Approach A (SAM trait + JIT-inlining) chosen for v1; approach B (full-`inline` derivation) noted as a future experimental branch.

## Test plan

- [x] `sbt --client core/compile` clean
- [x] `sbt --client core/test` — 117 tests pass
- [x] 100k-row round-trip via real file
- [x] UTF-8 / no BOM / `\r\n` vs `\n` byte-level assertions
- [x] Negative derivation tests (nested case class, non-product)