### PR TITLE
Fix release-drafter failing on pull_request events

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -12,15 +12,29 @@ permissions:
   contents: read
 
 jobs:
+  # Maintains the draft release on main. Only runs on push because the
+  # action sets target_commitish on the draft, and on pull_request events
+  # the GitHub-synthesized refs/pull/N/merge ref is not a valid commitish
+  # for the Releases API.
   update_release_draft:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
-      # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
-      pull-requests: write
     steps:
       - uses: release-drafter/release-drafter@v7.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Applies labels to PRs based on title patterns from .github/release-drafter.yml
+  # autolabeler config. Uses the dedicated sub-action so it doesn't try to
+  # update any release.
+  autolabeler:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@v7.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Release Drafter currently fails on every PR (e.g. PR #5) with `Validation Failed: target_commitish` because on `pull_request` events the API receives `refs/pull/N/merge` as the commitish when updating the existing draft release — that synthesized ref isn't valid for a Release.
- Fix is to split the action's two responsibilities by event: run the autolabeler only on PR events, run the releaser only on push-to-main. Each event then performs only what is valid in its context.

## Test plan

- [ ] PR opens with `Release Drafter` job green (autolabeler runs, releaser skipped).
- [ ] After merging to `main`, the workflow updates the existing `0.1.0` draft release without errors (releaser runs, autolabeler skipped).
- [ ] Autolabeler still applies `[feat]` / `[fix]` / `[skip]` / `[breaking]` title-pattern labels to PRs.