### PR TITLE
Add csvzen-zio module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ default, with configurable delimiter, quote character and line terminator.
 |-------------------|-----------------------------------------------------------------------------|
 | `csvzen-core`     | Streaming `CsvWriter`, `CsvConfig`, derived row encoders.                   |
 | `csvzen-test-kit` | Golden-file assertions for `CsvRowEncoder` output, on top of `zio-test`.    |
+| `csvzen-zio`      | ZIO bindings — `Scope`-managed `CsvWriter` and a `ZSink` for `ZStream`.     |
 
 ## Install
 
@@ -20,6 +21,7 @@ default, with configurable delimiter, quote character and line terminator.
 ```sbt
 libraryDependencies += "com.guizmaii" %% "csvzen-core"     % "<latest-version>"
 libraryDependencies += "com.guizmaii" %% "csvzen-test-kit" % "<latest-version>" % Test
+libraryDependencies += "com.guizmaii" %% "csvzen-zio"      % "<latest-version>"  // optional
 ```
 
 ### `-Xmax-inlines` for large case classes
@@ -285,6 +287,55 @@ auto-update mode.
 See [`modules/test-kit/README.md`](modules/test-kit/README.md) for `GoldenConfiguration`
 options (custom `CsvConfig`, sample size, `relativePath`) and the full
 workflow.
+
+## ZIO bindings
+
+`csvzen-zio` adds two thin helpers on top of `csvzen-core`:
+
+- **`openCsvWriter(path, config, …)`** opens a `CsvWriter` inside a `Scope`
+  so it's closed automatically at scope exit (success, failure, or
+  interruption). The `Scope` requirement lives in the return type
+  (`ZIO[Scope, Throwable, CsvWriter]`); the name doesn't need to repeat it.
+- **`csvSink[A](path, config, …)`** is a `ZSink[Any, Throwable, A, Nothing, Long]`
+  that writes a header row followed by one row per consumed `A`, returning
+  the number of rows written.
+
+```scala
+import com.guizmaii.csvzen.core.*
+import com.guizmaii.csvzen.zio.*
+import zio.*
+import zio.stream.ZStream
+import java.nio.file.Paths
+
+final case class Person(name: String, age: Int) derives CsvRowEncoder
+
+val people: ZStream[Any, Throwable, Person] = ZStream.fromIterable(
+  Vector(Person("Ada", 36), Person("Linus", 55), Person("Grace", 85))
+)
+
+val program: ZIO[Any, Throwable, Long] =
+  people.run(csvSink[Person](Paths.get("people.csv"), CsvConfig.default))
+```
+
+The sink owns the file handle for its lifetime; you don't have to manage it.
+For non-stream use cases, `openCsvWriter` plus `ZIO.scoped` gives the same
+guarantee.
+
+### Blocking executor
+
+Both the setup (open + write header) and each per-chunk write inside `csvSink`
+are already wrapped in `ZIO.blocking`, so file IO never lands on the default
+(CPU-bound) executor. **For the strongest guarantee — keeping the channel
+pump itself on the blocking pool between chunks, no executor ping-pong** —
+wrap the run call:
+
+```scala
+ZIO.blocking(stream.run(csvSink[Person](path, CsvConfig.default)))
+```
+
+That locks the entire sink-driven effect to the blocking executor for its
+full lifetime. Worth doing on hot streams where the per-chunk shift adds up;
+unnecessary for casual one-off writes.
 
 ## Build
 

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val root =
     .settings(noDoc *)
     .settings(publish / skip := true)
     .settings(crossScalaVersions := Nil) // https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Cross+building+a+project+statefully,
-    .aggregate(core, `test-kit`)
+    .aggregate(core, `test-kit`, zio)
 
 lazy val core =
   project
@@ -56,6 +56,22 @@ lazy val `test-kit` =
         "dev.zio" %% "zio-test"          % zioVersion,
         "dev.zio" %% "zio-test-magnolia" % zioVersion,
         "dev.zio" %% "zio-test-sbt"      % zioVersion % Test,
+      ),
+      testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    )
+
+lazy val zio =
+  project
+    .in(file("modules/zio"))
+    .dependsOn(core)
+    .settings(stdSettings *)
+    .settings(
+      name := "csvzen-zio",
+      libraryDependencies ++= Seq(
+        "dev.zio" %% "zio"          % zioVersion,
+        "dev.zio" %% "zio-streams"  % zioVersion,
+        "dev.zio" %% "zio-test"     % zioVersion % Test,
+        "dev.zio" %% "zio-test-sbt" % zioVersion % Test,
       ),
       testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     )

--- a/docs/superpowers/specs/2026-04-24-csvzen-design.md
+++ b/docs/superpowers/specs/2026-04-24-csvzen-design.md
@@ -38,25 +38,26 @@ csvzen keeps the codec concept and strips everything else: a typed emitter that 
 
 ## 3. Module layout
 
-Multi-module sbt build from the start, with a single live sub-project for v1:
+Multi-module sbt build, with each published artefact under `modules/`:
 
 ```
 csvzen/
   build.sbt                 (root aggregate)
   project/
-  core/
-    src/main/scala/com/guizmaii/csvzen/core/
-    src/main/scala/com/guizmaii/csvzen/core/internal/
-    src/test/scala/com/guizmaii/csvzen/core/
+  modules/
+    core/                   (csvzen-core)
+      src/main/scala/com/guizmaii/csvzen/core/
+      src/main/scala/com/guizmaii/csvzen/core/internal/
+      src/test/scala/com/guizmaii/csvzen/core/
+    test-kit/               (csvzen-test-kit, depends on core)
+    zio/                    (csvzen-zio, depends on core)
 ```
 
-- Published artefact id: `csvzen-core`.
-- Base package: `com.guizmaii.csvzen.core` (public API).
+- Published artefact ids: `csvzen-core`, `csvzen-test-kit`, `csvzen-zio`.
+- Base packages: `com.guizmaii.csvzen.core` (public API), `com.guizmaii.csvzen.testkit`, `com.guizmaii.csvzen.zio`.
 - Internals: `com.guizmaii.csvzen.core.internal` (not exported).
-- No external runtime dependencies. Stdlib + JDK only.
-- Test dependency: `dev.zio::zio-test` / `dev.zio::zio-test-sbt` (matches the broader workspace convention — no runtime impact).
+- `csvzen-core` has no external runtime dependencies — stdlib + JDK only. `csvzen-test-kit` depends on `dev.zio::zio-test` + `dev.zio::zio-test-magnolia`. `csvzen-zio` depends on `dev.zio::zio` + `dev.zio::zio-streams`.
 - Scala 3.3.7; max line length 120 (existing project scalafmt assumed).
-- Adding `csvzen-zio` later is a small `build.sbt` addition (`lazy val zio = project.dependsOn(core)`); no public-API changes required.
 
 ## 4. Public API
 
@@ -385,7 +386,7 @@ For each of the 28 shipped types, asserted via `FieldEmitter` + `StringWriter`:
 ## 10. Future considerations
 
 - **Approach B: full-`inline` derivation.** Replace the `Array[CsvFieldEncoder[Any]]` + `productElement` machinery with a fully-unrolled inline macro that expands to `out.emitInt(a.age); out.emitString(a.name); …` at each call site. Eliminates the remaining `productElement` boxing of primitive fields and all typeclass dispatch, but costs compile time and debuggability. To be explored on an experimental branch and benchmarked against A.
-- **`csvzen-zio` module.** `CsvWriter.managed(path, config): ZIO[Scope, Throwable, CsvWriter]` plus a `ZSink[Any, Throwable, A, Nothing, Long]` factory (given `CsvRowEncoder[A]`) returning row count.
+- **`csvzen-zio` module** *(shipped)*. `openCsvWriter(path, config, …): ZIO[Scope, Throwable, CsvWriter]` plus a `ZSink[Any, Throwable, A, Nothing, Long]` factory (`csvSink[A: CsvRowEncoder]`) returning row count.
 - **`csvzen-test-kit` module** *(shipped)*. A zio-test integration providing golden-file assertions for CSV output, modelled directly on `zio-json-golden` for ergonomic parity with the rest of the ZIO ecosystem.
 
   **Public API:**

--- a/modules/zio/src/main/scala/com/guizmaii/csvzen/zio/open.scala
+++ b/modules/zio/src/main/scala/com/guizmaii/csvzen/zio/open.scala
@@ -1,0 +1,26 @@
+package com.guizmaii.csvzen.zio
+
+import com.guizmaii.csvzen.core.{CsvConfig, CsvWriter}
+import zio.{Scope, ZIO}
+
+import java.nio.charset.{Charset, StandardCharsets}
+import java.nio.file.{OpenOption, Path}
+
+/**
+ * Opens a [[com.guizmaii.csvzen.core.CsvWriter]] inside a `Scope`, automatically
+ * closing it when the scope exits (success, failure, or interruption). Mirrors the
+ * defaults of `CsvWriter.open`: UTF-8 and, when no `options` are provided, the
+ * standard `newBufferedWriter` open options (`CREATE`, `TRUNCATE_EXISTING`, `WRITE`).
+ *
+ * If you pass any `options`, they are forwarded as-is to `Files.newBufferedWriter`
+ * and **replace** the defaults rather than adding on top of them. Callers who want
+ * create/truncate/write semantics alongside a custom option (e.g. `APPEND`) must
+ * include the desired `OpenOption`s explicitly.
+ */
+def openCsvWriter(
+  path: Path,
+  config: CsvConfig,
+  charset: Charset = StandardCharsets.UTF_8,
+  options: OpenOption*,
+): ZIO[Scope, Throwable, CsvWriter] =
+  ZIO.fromAutoCloseable(ZIO.attemptBlocking(CsvWriter.open(path, config, charset, options*)))

--- a/modules/zio/src/main/scala/com/guizmaii/csvzen/zio/sink.scala
+++ b/modules/zio/src/main/scala/com/guizmaii/csvzen/zio/sink.scala
@@ -1,0 +1,74 @@
+package com.guizmaii.csvzen.zio
+
+import com.guizmaii.csvzen.core.{CsvConfig, CsvRowEncoder, CsvWriter}
+import zio.{Chunk, ZIO, ZNothing}
+import zio.stream.{ZChannel, ZSink}
+
+import scala.annotation.threadUnsafe
+
+import java.nio.charset.{Charset, StandardCharsets}
+import java.nio.file.{OpenOption, Path}
+
+/**
+ * A `ZSink` that writes a stream of `A` to `path` as CSV: one header row first,
+ * then one row per `A`. The terminal value is the number of rows written
+ * (header excluded).
+ *
+ * The underlying `CsvWriter` is opened in a `Scope` and closed at sink completion
+ * (success, failure, or interruption). Use this with any
+ * `ZStream[Any, Throwable, A]`:
+ *
+ * {{{
+ * stream.run(csvSink[Person](path, CsvConfig.default))
+ * }}}
+ *
+ * '''Blocking executor.''' Setup (open + write header) and each per-chunk write
+ * use `ZIO.attemptBlocking`, so the file IO never runs on the default (CPU-bound)
+ * executor. For the strongest guarantee — keeping the channel pump itself on
+ * the blocking pool between chunks, no executor ping-pong — wrap the run call:
+ *
+ * {{{
+ * ZIO.blocking(stream.run(csvSink[Person](path, CsvConfig.default)))
+ * }}}
+ *
+ * That locks the entire sink-driven effect to the blocking executor for its
+ * full lifetime, which matters for hot streams where the per-chunk shift adds
+ * up.
+ */
+def csvSink[A](
+  path: Path,
+  config: CsvConfig,
+  charset: Charset = StandardCharsets.UTF_8,
+  options: OpenOption*,
+)(using enc: CsvRowEncoder[A]): ZSink[Any, Throwable, A, Nothing, Long] =
+  ZSink.unwrapScoped {
+    // Register the writer with the Scope BEFORE writing the header. If we bundled
+    // `writeHeader` into the same `attemptBlocking` as `open`, a throw from the
+    // header write would fail the acquire effect and `fromAutoCloseable` would
+    // never register a close finalizer — the just-opened writer would leak.
+    ZIO.blocking {
+      ZIO
+        .fromAutoCloseable(ZIO.attempt(CsvWriter.open(path, config, charset, options*)))
+        .flatMap { writer =>
+          ZIO
+            .attempt(writer.writeHeader[A]())
+            .as {
+              var count = 0L
+
+              @threadUnsafe
+              lazy val loop: ZChannel[Any, ZNothing, Chunk[A], Any, Throwable, Chunk[Nothing], Long] =
+                ZChannel.readWithCause(
+                  in = chunk =>
+                    ZChannel.fromZIO(ZIO.attemptBlocking {
+                      writer.writeAll(chunk)
+                      count += chunk.size
+                    }) *> loop,
+                  halt = cause => ZChannel.refailCause(cause),
+                  done = _ => ZChannel.succeedNow(count),
+                )
+
+              ZSink.fromChannel(loop)
+            }
+        }
+    }
+  }

--- a/modules/zio/src/test/scala/com/guizmaii/csvzen/zio/CsvZioSpec.scala
+++ b/modules/zio/src/test/scala/com/guizmaii/csvzen/zio/CsvZioSpec.scala
@@ -1,0 +1,143 @@
+package com.guizmaii.csvzen.zio
+
+import com.guizmaii.csvzen.core.{CsvConfig, CsvRowEncoder}
+import zio.{Chunk, Scope, ZIO, durationInt}
+import zio.stream.ZStream
+import zio.test.*
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+
+object CsvZioSpec extends ZIOSpecDefault {
+
+  private final case class Person(name: String, age: Int) derives CsvRowEncoder
+
+  private def withTmpFile[R, A](use: Path => ZIO[R, Throwable, A]): ZIO[R, Throwable, A] =
+    ZIO.acquireReleaseWith(
+      ZIO.attemptBlocking(Files.createTempFile("csvzen-zio-", ".csv"))
+    )(p => ZIO.attemptBlocking(Files.deleteIfExists(p)).ignore)(use)
+
+  private def readUtf8(p: Path): ZIO[Any, Throwable, String] =
+    ZIO.attemptBlocking(Files.readString(p, StandardCharsets.UTF_8))
+
+  private val managedSpec =
+    suite("openCsvWriter")(
+      test("opens a CsvWriter, lets the body write rows, and closes it at scope exit") {
+        withTmpFile { path =>
+          ZIO
+            .scoped(
+              openCsvWriter(path, CsvConfig.default).flatMap(w =>
+                ZIO.attemptBlocking {
+                  w.writeHeader[Person]()
+                  w.writeRow(Person("Ada", 36))
+                  w.writeRow(Person("Linus", 55))
+                }
+              )
+            )
+            .zipRight(readUtf8(path))
+            .map(contents => assertTrue(contents == "name,age\r\nAda,36\r\nLinus,55\r\n"))
+        }
+      }
+    )
+
+  private val sinkSpec =
+    suite("csvSink")(
+      test("consumes a ZStream of A, writes header + rows, returns the row count") {
+        withTmpFile { path =>
+          val rows = Vector(Person("Ada", 36), Person("Linus", 55), Person("Grace", 85))
+          val sink = csvSink[Person](path, CsvConfig.default)
+          ZStream
+            .fromIterable(rows)
+            .run(sink)
+            .flatMap(count =>
+              readUtf8(path).map(contents =>
+                assertTrue(
+                  count == 3L,
+                  contents == "name,age\r\nAda,36\r\nLinus,55\r\nGrace,85\r\n",
+                )
+              )
+            )
+        }
+      },
+      test("writes only the header row when the stream is empty") {
+        withTmpFile { path =>
+          val sink = csvSink[Person](path, CsvConfig.default)
+          ZStream.empty
+            .run(sink)
+            .flatMap(count => readUtf8(path).map(contents => assertTrue(count == 0L, contents == "name,age\r\n")))
+        }
+      },
+      // Forces multiple chunks through the channel to lock in the running-count
+      // recursion: each chunk must contribute its size to the running total, not
+      // overwrite it. `ZStream.fromIterable` would emit a single chunk and hide
+      // the bug.
+      test("counts rows correctly across multiple chunks") {
+        withTmpFile { path =>
+          val chunk1 = Chunk(Person("Ada", 36), Person("Linus", 55))
+          val chunk2 = Chunk(Person("Grace", 85))
+          val chunk3 = Chunk(Person("Edsger", 72), Person("Alan", 41), Person("Donald", 86))
+          val sink   = csvSink[Person](path, CsvConfig.default)
+          ZStream
+            .fromChunks(chunk1, chunk2, chunk3)
+            .run(sink)
+            .flatMap(count =>
+              readUtf8(path).map(contents =>
+                assertTrue(
+                  count == 6L,
+                  contents ==
+                    "name,age\r\n" +
+                    "Ada,36\r\nLinus,55\r\n" +
+                    "Grace,85\r\n" +
+                    "Edsger,72\r\nAlan,41\r\nDonald,86\r\n",
+                )
+              )
+            )
+        }
+      },
+      // Failure-path: when the upstream fails after the sink has already written
+      // some rows, the run must propagate the failure AND the writer must have
+      // been closed (otherwise we'd be sitting on a leaked file handle and the
+      // partial output would be invisible until GC).
+      test("propagates upstream failures and closes the writer") {
+        withTmpFile { path =>
+          val boom   = new RuntimeException("boom")
+          val sink   = csvSink[Person](path, CsvConfig.default)
+          val stream = ZStream.fromIterable(Vector(Person("Ada", 36))) ++ ZStream.fail(boom)
+          stream
+            .run(sink)
+            .either
+            .flatMap(result =>
+              readUtf8(path).map(contents =>
+                assertTrue(
+                  // run failed with our boom
+                  result.left.toOption.exists(_.getMessage == "boom"),
+                  // writer was finalised: the partial output (header + Ada) is
+                  // flushed to disk and the file is readable
+                  contents == "name,age\r\nAda,36\r\n",
+                )
+              )
+            )
+        }
+      },
+      // Interruption-path: the same Scope finalizer must fire when the fiber is
+      // interrupted mid-pull. We use ZStream.never so the sink only ever writes
+      // the header, then we interrupt and read the file back. `fiber.interrupt`
+      // returns once finalisers have run, so reading after it is race-free.
+      // The sleep escapes TestClock via `Live.live` — without that, ZIOSpecDefault's
+      // TestClock would never advance and the sleep would hang.
+      test("releases the writer on fiber interruption") {
+        withTmpFile { path =>
+          val sink = csvSink[Person](path, CsvConfig.default)
+          ZStream.never
+            .run(sink)
+            .fork
+            .flatMap(fiber => Live.live(ZIO.sleep(50.millis)).zipRight(fiber.interrupt))
+            .zipRight(readUtf8(path))
+            .map(contents => assertTrue(contents == "name,age\r\n"))
+        }
+      },
+    )
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("csvzen-zio")(managedSpec, sinkSpec)
+}


### PR DESCRIPTION
## Summary

Adds **`csvzen-zio`**: ZIO bindings for csvzen-core. Two thin helpers, no surprises.

- **`openCsvWriter(path, config, charset, options*): ZIO[Scope, Throwable, CsvWriter]`** — opens a `CsvWriter` inside a `Scope` so it's closed automatically at scope exit (success, failure, or interruption). The `Scope` requirement lives in the return type; the name doesn't repeat it (no ZIO 1 `Managed`-style prefix).
- **`csvSink[A: CsvRowEncoder](path, config, charset, options*): ZSink[Any, Throwable, A, A, Long]`** — writes a header row followed by one row per consumed `A`, returning the number of rows written. The underlying file handle is owned by the sink for its lifetime.

Lives at `modules/zio/`, depends on `core` + `dev.zio:zio` + `dev.zio:zio-streams` (compile), `dev.zio:zio-test` + `dev.zio:zio-test-sbt` (test).

## API

```scala
import com.guizmaii.csvzen.core.*
import com.guizmaii.csvzen.zio.*
import zio.*
import zio.stream.ZStream
import java.nio.file.Paths

final case class Person(name: String, age: Int) derives CsvRowEncoder

val people: ZStream[Any, Throwable, Person] = ZStream.fromIterable(
  Vector(Person("Ada", 36), Person("Linus", 55), Person("Grace", 85))
)

// One-shot stream → file with row count:
val rowsWritten: ZIO[Any, Throwable, Long] =
  people.run(csvSink[Person](Paths.get("people.csv"), CsvConfig.default))

// Manual scope when you need imperative control over the writer:
ZIO.scoped {
  for {
    w <- openCsvWriter(path, CsvConfig.default)
    _ <- ZIO.attemptBlocking(w.writeHeader[Person]())
    _ <- ZIO.attemptBlocking(w.writeRow(Person("Ada", 36)))
  } yield ()
}
```

## Implementation

- `openCsvWriter` is a one-liner: `ZIO.fromAutoCloseable(ZIO.attemptBlocking(CsvWriter.open(...)))`. `CsvWriter` already implements `AutoCloseable + Flushable`.
- `csvSink` uses `ZSink.unwrapScoped` to open the writer + write the header at sink construction, then `ZSink.foldLeftZIO` to consume each `A` and increment a counter.

## Test plan

- [x] `openCsvWriter` opens, writes header + rows in a scoped block, closes at scope exit. File contents byte-exact (`name,age\r\nAda,36\r\nLinus,55\r\n`).
- [x] `csvSink` consumes a populated `ZStream`, returns the row count, file contents byte-exact.
- [x] `csvSink` on an empty stream writes only the header row, returns `0L`.
- [x] Full suite: 129 (core) + 3 (test-kit) + 3 (zio) = 135 tests, all green.
- [x] `sbt check` clean (scalafix + scalafmt).
- [ ] CI green on the PR.