### PR TITLE
Add FieldEmitter::emit(Option[A]) for ergonomic optional fields

### DIFF
--- a/modules/core/src/main/scala/com/guizmaii/csvzen/core/FieldEmitter.scala
+++ b/modules/core/src/main/scala/com/guizmaii/csvzen/core/FieldEmitter.scala
@@ -76,6 +76,17 @@ final class FieldEmitter private[core] (out: Writer, config: CsvConfig) {
     out.write(java.lang.Double.toString(d))
   }
 
+  /**
+   * Emits an `Option[A]`: `Some(a)` is encoded via the in-scope `CsvFieldEncoder[A]`,
+   * `None` is written as an empty cell. Lets custom encoders write
+   * `out.emit(record.optionalField)` instead of pattern-matching on every `Option`.
+   */
+  def emit[A](opt: Option[A])(using enc: CsvFieldEncoder[A]): Unit =
+    opt match {
+      case Some(a) => enc.encode(a, this)
+      case None    => emitEmpty()
+    }
+
   // Process digits with `n <= 0` throughout the loop. Positive inputs are negated
   // once on entry so a single `('0' - n % 10)` extraction handles both signs. This
   // avoids the Int.MinValue / Long.MinValue special case: their absolute value has

--- a/modules/core/src/test/scala/com/guizmaii/csvzen/core/FieldEmitterSpec.scala
+++ b/modules/core/src/test/scala/com/guizmaii/csvzen/core/FieldEmitterSpec.scala
@@ -253,6 +253,38 @@ object FieldEmitterSpec extends ZIOSpecDefault {
       },
     )
 
+  private val emitOptionSpec =
+    suite("::emit(Option[A])")(
+      test("Some(value) writes the encoded inner value (String)") {
+        assertTrue(firstField(cfg)(_.emit(Some("hello"))) == "hello")
+      },
+      test("Some(value) writes the encoded inner value (Int)") {
+        assertTrue(firstField(cfg)(_.emit(Some(42))) == "42")
+      },
+      test("Some(value) writes the encoded inner value (Boolean)") {
+        assertTrue(firstField(cfg)(_.emit(Some(true))) == "true")
+      },
+      test("None writes an empty cell") {
+        assertTrue(firstField(cfg)(_.emit(Option.empty[String])) == "")
+      },
+      test("Some quotes/escapes the inner value via its encoder") {
+        // "a,b" needs quoting per the default CSV config — emit(Some(...)) must
+        // route through emitString, not bypass the escaping logic.
+        assertTrue(firstField(cfg)(_.emit(Some("a,b"))) == "\"a,b\"")
+      },
+      test("delimiter placement: None then Some, Some then None") {
+        val noneThenSome =
+          firstField(cfg) { e => e.emit(Option.empty[Int]); e.emit(Some(1)) }
+        val someThenNone =
+          firstField(cfg) { e => e.emit(Some(1)); e.emit(Option.empty[Int]) }
+        assertTrue(noneThenSome == ",1", someThenNone == "1,")
+      },
+      test("works for any type with a CsvFieldEncoder (UUID)") {
+        val u = java.util.UUID.fromString("00000000-0000-0000-0000-000000000001")
+        assertTrue(firstField(cfg)(_.emit(Some(u))) == u.toString)
+      },
+    )
+
   override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("FieldEmitter")(
       emitIntSpec,
@@ -265,6 +297,7 @@ object FieldEmitterSpec extends ZIOSpecDefault {
       emitCharSpec,
       emitStringSpec,
       emitEmptySpec,
+      emitOptionSpec,
       delimiterPlacementSpec,
     )
 }


### PR DESCRIPTION
## Summary

Adds `FieldEmitter::emit[A](opt: Option[A])(using CsvFieldEncoder[A]): Unit`. Lets callers writing custom `CsvRowEncoder` instances drop the per-field `match { Some => emitX(...); None => emitEmpty() }` boilerplate:

```scala
// before
person.maybeAge match {
  case Some(age) => out.emitInt(age)
  case None      => out.emitEmpty()
}

// after
out.emit(person.maybeAge)
```

`Some` is routed through the in-scope `CsvFieldEncoder[A]` (so escaping/formatting matches the rest of the pipeline), `None` is written as an empty cell.

The auto-derived path already had this behaviour via `CsvFieldEncoder.optionEncoder` — this PR just exposes the same semantics directly on `FieldEmitter` so the imperative custom-encoder API gets it too.

## Test plan

- [x] `sbt --client core/test` — 136 tests pass (7 new `::emit(Option[A])` cases: Some/None for `String`/`Int`/`Boolean`/`UUID`, escaping path, delimiter placement around `None`).